### PR TITLE
use 180 days instead of 6 months

### DIFF
--- a/eval/src/main/java/ch/admin/bag/covidcertificate/eval/utils/AcceptanceCriterias.kt
+++ b/eval/src/main/java/ch/admin/bag/covidcertificate/eval/utils/AcceptanceCriterias.kt
@@ -8,8 +8,8 @@ object AcceptanceCriterias {
 	const val RAT_TEST_VALIDITY_IN_HOURS = 24L
 	const val SINGLE_VACCINE_VALIDITY_OFFSET_IN_DAYS = 15L
 	const val VACCINE_IMMUNITY_DURATION_IN_DAYS = 180L
-	const val RECOVERY_OFFSET_VALID_UNTIL = 6L
-	const val RECOVERY_OFFSET_VALID_FROM = 10L
+	const val RECOVERY_OFFSET_VALID_UNTIL_DAYS = 180L
+	const val RECOVERY_OFFSET_VALID_FROM_DAYS = 10L
 }
 
 enum class TestType(val code: String) {

--- a/eval/src/main/java/ch/admin/bag/covidcertificate/eval/utils/RecoveryEntryUtils.kt
+++ b/eval/src/main/java/ch/admin/bag/covidcertificate/eval/utils/RecoveryEntryUtils.kt
@@ -43,12 +43,12 @@ fun RecoveryEntry.getCertificateIdentifier(): String {
 
 fun RecoveryEntry.validFromDate(): LocalDateTime? {
 	val firstPositiveResultDate = this.firstPostiveResult() ?: return null
-	return firstPositiveResultDate.plusDays(AcceptanceCriterias.RECOVERY_OFFSET_VALID_FROM)
+	return firstPositiveResultDate.plusDays(AcceptanceCriterias.RECOVERY_OFFSET_VALID_FROM_DAYS)
 }
 
 fun RecoveryEntry.validUntilDate(): LocalDateTime? {
 	val firstPositiveResultDate = this.firstPostiveResult() ?: return null
-	return firstPositiveResultDate.plusMonths(AcceptanceCriterias.RECOVERY_OFFSET_VALID_UNTIL)
+	return firstPositiveResultDate.plusDays(AcceptanceCriterias.RECOVERY_OFFSET_VALID_UNTIL_DAYS)
 }
 
 fun RecoveryEntry.firstPostiveResult(): LocalDateTime? {


### PR DESCRIPTION
The validity is now defined as 180 days from first positive test result. Before it used 6 Months, which is not a fixed time-interval.

Further, the constant names were updated to indicate the units of the unit less numbers.