### PR TITLE
[DRAFT] Add JWS Interceptor

### DIFF
--- a/eval/build.gradle
+++ b/eval/build.gradle
@@ -72,6 +72,11 @@ dependencies {
 	implementation 'com.squareup.moshi:moshi:1.11.0'
 	kapt "com.squareup.moshi:moshi-kotlin-codegen:1.11.0"
 
+	//JWS Library
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	api 'io.jsonwebtoken:jjwt-impl:0.11.2',
+			'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
 	testImplementation 'junit:junit:4.+'
 	androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 	androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/eval/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsInterceptor.kt
+++ b/eval/src/main/java/ch/admin/bag/covidcertificate/eval/net/JwsInterceptor.kt
@@ -1,0 +1,65 @@
+package ch.admin.bag.covidcertificate.eval.net
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwts
+import okhttp3.Interceptor
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Response
+
+import okhttp3.ResponseBody.Companion.toResponseBody
+import java.io.IOException
+import java.security.PublicKey
+
+import java.security.SignatureException
+
+/// application/json media type for the payload of a JWS
+val APPLICATION_JSON = "application/json".toMediaType()
+
+/**
+   This class can be used as an interceptor to verify a JWS and return a response with a plain JSON-Object.
+   Since we need a JWS with a JSON body (we explicitly ask for it), we can savely assume that the content-type
+   is `application/json`.
+ The signature of the JWS is verified with `publicKey`.
+ */
+ class JwsInterceptor(private val publicKey: PublicKey) :
+        Interceptor {
+    @Throws(IOException::class)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response: Response = chain.proceed(chain.request())
+        if (!response.isSuccessful) {
+            return response
+        }
+        if (response.cacheResponse != null) {
+            return response
+        }
+        val jws = response.body!!.string()
+
+        var body = ""
+        try {
+            val claimsJws : Jws<Claims> = Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(jws)
+            // now that the JWS is verified, we can safely assume that the body can be trusted, so serialize it to JSON again
+            body = Moshi.Builder().build().adapter<Claims>(Types.newParameterizedType(Map::class.java, String::class.java, Object::class.java)).toJson(claimsJws.body)
+        } catch (e: io.jsonwebtoken.security.SignatureException) {
+            throw SignatureException("Invalid Signature")
+        } catch (o: ExpiredJwtException) {
+            throw SignatureException("Expired JWT")
+        }
+        // SAFE ZONE
+        // from here on body contains a JSON-string of the payload of the JWS, whose signature we verified.
+
+        return response.newBuilder()
+                .body(
+                        body.toResponseBody(APPLICATION_JSON)
+                ).build()
+    }
+}


### PR DESCRIPTION
This interceptor aims to provide a generic framework for parsing and verifying JWS. Since the payload of the JWS is just a JSON, the JWS provide a nice and standardized way of verifying the integrity and authenticity of JSON-Objects.

By not using a HTTP-Header to inspect, we can avoid certain CloudFront pop issues, where header/body of cached responses mismatch.

Before we can merge, we should check if there is a clever way of not having to serialize the Claims body again, or base64decode the JWS (since the interceptor needs to return a Response object, which can only contain Strings, or ByteArrays)