### PR TITLE
Remove sensitive logging statements

### DIFF
--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/verification/CertificateVerifier.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/verification/CertificateVerifier.kt
@@ -1,7 +1,6 @@
 package ch.admin.bag.covidcertificate.common.verification
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData

--- a/eval/src/main/java/ch/admin/bag/covidcertificate/eval/chain/VerificationCoseService.kt
+++ b/eval/src/main/java/ch/admin/bag/covidcertificate/eval/chain/VerificationCoseService.kt
@@ -8,7 +8,6 @@ import COSE.HeaderKeys
 import COSE.MessageTag
 import COSE.OneKey
 import COSE.Sign1Message
-import android.util.Log
 import ch.admin.bag.covidcertificate.eval.models.CertType
 import ch.admin.bag.covidcertificate.eval.models.Jwk
 import ch.admin.bag.covidcertificate.eval.utils.toBase64
@@ -24,7 +23,6 @@ class VerificationCoseService(private val keys: List<Jwk>) {
 				try {
 					val kid: ByteArray = signature.findAttribute(HeaderKeys.KID)?.GetByteString()
 						?: throw IllegalArgumentException("No kid in COSE object")
-					Log.d(TAG, "COSE signature is with kid=${kid.toBase64()}")
 
 					keys
 						// Potentially there are many signing keys. Filter on the kid to save the expensive public crypto key operations.

--- a/eval/src/main/java/ch/admin/bag/covidcertificate/eval/models/Jwk.kt
+++ b/eval/src/main/java/ch/admin/bag/covidcertificate/eval/models/Jwk.kt
@@ -61,7 +61,7 @@ data class Jwk(
 			}
 		} catch (e: Exception) {
 			// Can throw e.g. if the (x, y) pair is not a point on the curve
-			Log.e(TAG, "Error initialising PublicKey for kid $kid: $e")
+			e.printStackTrace()
 		}
 		return null
 	}


### PR DESCRIPTION
Remove most log statements (grepping for occurrences of android.util.Log) to prevent leaking information to apps with logcat access.