### PR TITLE
Block screenshots of dialogs too

### DIFF
--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/util/UiUtil.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/util/UiUtil.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.common.util
+
+import android.view.Window
+import android.view.WindowManager
+
+private val allowlistedFlavours = listOf("abn", "dev")
+
+fun Window.setSecureFlagToBlockScreenshots(flavor: String) {
+	if (!allowlistedFlavours.contains(flavor)) {
+		setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+	}
+}

--- a/verifier/src/main/java/ch/admin/bag/covidcertificate/verifier/MainActivity.kt
+++ b/verifier/src/main/java/ch/admin/bag/covidcertificate/verifier/MainActivity.kt
@@ -12,12 +12,12 @@ package ch.admin.bag.covidcertificate.verifier
 
 import android.content.DialogInterface
 import android.os.Bundle
-import android.view.WindowManager
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import ch.admin.bag.covidcertificate.common.config.ConfigModel
 import ch.admin.bag.covidcertificate.common.util.UrlUtil
+import ch.admin.bag.covidcertificate.common.util.setSecureFlagToBlockScreenshots
 import ch.admin.bag.covidcertificate.verifier.databinding.ActivityMainBinding
 import ch.admin.bag.covidcertificate.verifier.networking.ConfigRepository
 
@@ -36,10 +36,7 @@ class MainActivity : AppCompatActivity() {
 		val view = binding.root
 		setContentView(view)
 
-		val allowlistedFlavours = listOf("abn", "dev")
-		if (!allowlistedFlavours.contains(BuildConfig.FLAVOR)) {
-			window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
-		}
+		window.setSecureFlagToBlockScreenshots(BuildConfig.FLAVOR)
 
 		if (savedInstanceState == null) {
 			supportFragmentManager.beginTransaction()
@@ -64,6 +61,7 @@ class MainActivity : AppCompatActivity() {
 				.setPositiveButton(R.string.force_update_button, null)
 				.setCancelable(false)
 				.create()
+				.apply { window?.setSecureFlagToBlockScreenshots(BuildConfig.FLAVOR) }
 			forceUpdateDialog.setOnShowListener {
 				forceUpdateDialog.getButton(DialogInterface.BUTTON_POSITIVE)
 					.setOnClickListener {

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/MainActivity.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/MainActivity.kt
@@ -13,14 +13,14 @@ package ch.admin.bag.covidcertificate.wallet
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
-import android.view.WindowManager
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import ch.admin.bag.covidcertificate.common.util.UrlUtil
 import ch.admin.bag.covidcertificate.common.config.ConfigModel
+import ch.admin.bag.covidcertificate.common.util.UrlUtil
+import ch.admin.bag.covidcertificate.common.util.setSecureFlagToBlockScreenshots
 import ch.admin.bag.covidcertificate.wallet.data.SecureStorage
 import ch.admin.bag.covidcertificate.wallet.databinding.ActivityMainBinding
 import ch.admin.bag.covidcertificate.wallet.homescreen.HomeFragment
@@ -53,10 +53,7 @@ class MainActivity : AppCompatActivity() {
 		val view = binding.root
 		setContentView(view)
 
-		val allowlistedFlavours = listOf("abn", "dev")
-		if (!allowlistedFlavours.contains(BuildConfig.FLAVOR)) {
-			window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
-		}
+		window.setSecureFlagToBlockScreenshots(BuildConfig.FLAVOR)
 
 		if (savedInstanceState == null) {
 			val onboardingCompleted: Boolean = secureStorage.getOnboardingCompleted()
@@ -90,6 +87,7 @@ class MainActivity : AppCompatActivity() {
 				.setPositiveButton(R.string.force_update_button, null)
 				.setCancelable(false)
 				.create()
+				.apply { window?.setSecureFlagToBlockScreenshots(BuildConfig.FLAVOR) }
 			forceUpdateDialog.setOnShowListener {
 				forceUpdateDialog.getButton(DialogInterface.BUTTON_POSITIVE)
 					.setOnClickListener {

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import ch.admin.bag.covidcertificate.common.util.DEFAULT_DISPLAY_DATE_FORMATTER
 import ch.admin.bag.covidcertificate.common.util.parseIsoTimeAndFormat
+import ch.admin.bag.covidcertificate.common.util.setSecureFlagToBlockScreenshots
 import ch.admin.bag.covidcertificate.common.verification.CertificateVerifier
 import ch.admin.bag.covidcertificate.common.verification.VerificationState
 import ch.admin.bag.covidcertificate.common.views.animateBackgroundTintColor
@@ -34,6 +35,7 @@ import ch.admin.bag.covidcertificate.common.views.hideAnimated
 import ch.admin.bag.covidcertificate.common.views.showAnimated
 import ch.admin.bag.covidcertificate.eval.models.Bagdgc
 import ch.admin.bag.covidcertificate.eval.utils.*
+import ch.admin.bag.covidcertificate.wallet.BuildConfig
 import ch.admin.bag.covidcertificate.wallet.CertificatesViewModel
 import ch.admin.bag.covidcertificate.wallet.R
 import ch.admin.bag.covidcertificate.wallet.databinding.FragmentCertificateDetailBinding
@@ -101,6 +103,7 @@ class CertificateDetailFragment : Fragment() {
 				}
 				.setCancelable(true)
 				.create()
+				.apply { window?.setSecureFlagToBlockScreenshots(BuildConfig.FLAVOR) }
 				.show()
 		}
 


### PR DESCRIPTION
The dialogs currently don't contain much sensitive information ("You should update the app." "Do you really want to delete?"), but we should still aim for completeness.