### PR TITLE
BSD-3-Clause and MIT licence URL

### DIFF
--- a/common/src/main/assets/impressum/de/licence.html
+++ b/common/src/main/assets/impressum/de/licence.html
@@ -38,8 +38,8 @@
     <div class="licence-list">
     <ul>
 <li><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a></li>
-<li><a href="https://github.com/DIGGSweden/dgc-java/blob/main/LICENSE">MIT license</a></li>
-<li><a href="https://github.com/cose-wg/COSE-JAVA/blob/master/LICENSE">BSD-3-Clause license</a></li>
+<li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
+<li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 </ul>
     </div>
 </div>

--- a/common/src/main/assets/impressum/en/licence.html
+++ b/common/src/main/assets/impressum/en/licence.html
@@ -38,8 +38,8 @@
     <div class="licence-list">
     <ul>
 <li><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a></li>
-<li><a href="https://github.com/DIGGSweden/dgc-java/blob/main/LICENSE">MIT license</a></li>
-<li><a href="https://github.com/cose-wg/COSE-JAVA/blob/master/LICENSE">BSD-3-Clause license</a></li>
+<li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
+<li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 </ul>
     </div>
 </div>

--- a/common/src/main/assets/impressum/fr/licence.html
+++ b/common/src/main/assets/impressum/fr/licence.html
@@ -38,8 +38,8 @@
     <div class="licence-list">
     <ul>
 <li><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a></li>
-<li><a href="https://github.com/DIGGSweden/dgc-java/blob/main/LICENSE">MIT license</a></li>
-<li><a href="https://github.com/cose-wg/COSE-JAVA/blob/master/LICENSE">BSD-3-Clause license</a></li>
+<li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
+<li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 </ul>
     </div>
 </div>

--- a/common/src/main/assets/impressum/it/licence.html
+++ b/common/src/main/assets/impressum/it/licence.html
@@ -38,8 +38,8 @@
     <div class="licence-list">
     <ul>
 <li><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a></li>
-<li><a href="https://github.com/DIGGSweden/dgc-java/blob/main/LICENSE">MIT license</a></li>
-<li><a href="https://github.com/cose-wg/COSE-JAVA/blob/master/LICENSE">BSD-3-Clause license</a></li>
+<li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
+<li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 </ul>
     </div>
 </div>


### PR DESCRIPTION
I might be totally wrong but referring to the BSD-3-Clause and MIT licence on the original page would be better, although the linked to one is identical, of course.