### PR TITLE
Add gradle wrapper validation

### DIFF
--- a/.github/workflows/appcenter_verifier_abn.yml
+++ b/.github/workflows/appcenter_verifier_abn.yml
@@ -1,4 +1,4 @@
-name: Android Build AppCenter Verifier Abn
+name: Build Verifier ABN
 
 on:
   push:

--- a/.github/workflows/appcenter_verifier_dev.yml
+++ b/.github/workflows/appcenter_verifier_dev.yml
@@ -1,4 +1,4 @@
-name: Android Build Verifier
+name: Build Verifier DEV
 
 on:
   push:

--- a/.github/workflows/appcenter_verifier_prod.yml
+++ b/.github/workflows/appcenter_verifier_prod.yml
@@ -1,4 +1,4 @@
-name: Android Build AppCenter Verifier Prod
+name: Build Verifier PROD
 
 on:
   push:

--- a/.github/workflows/appcenter_wallet_abn.yml
+++ b/.github/workflows/appcenter_wallet_abn.yml
@@ -1,4 +1,4 @@
-name: Android Build AppCenter Wallet Abn
+name: Build Wallet ABN
 
 on:
   push:

--- a/.github/workflows/appcenter_wallet_dev.yml
+++ b/.github/workflows/appcenter_wallet_dev.yml
@@ -1,4 +1,4 @@
-name: Android Build Wallet
+name: Build Wallet DEV
 
 on:
   push:

--- a/.github/workflows/appcenter_wallet_prod.yml
+++ b/.github/workflows/appcenter_wallet_prod.yml
@@ -1,4 +1,4 @@
-name: Android Build AppCenter Wallet Prod
+name: Build Wallet PROD
 
 on:
   push:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@1ed3d1cbba6f8f077128463ced1769606d17b77b

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,13 @@
+name: Validate Gradle Wrapper
+
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Motivated by #79 to prevent commits introducing bad gradle jars.
See https://github.com/marketplace/actions/gradle-wrapper-validation.

Also unifies workflow naming.