### PR TITLE
Rename api key to app token

### DIFF
--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -49,19 +49,21 @@ android {
 	}
 
 	productFlavors {
+		// These app tokens are reserved for the official COVID Certificate Check app.
+		// If you intend to integrate the CovidCertificate-SDK into your app, please get in touch with BIT/BAG to get a token assigned.
 		dev {
 			buildConfigField "String", "BASE_URL", '"https://www.cc-d.bit.admin.ch/app/verifier/v1/"'
-			buildConfigField "String", "SDK_API_KEY", '"7f64903d-4420-4cc3-ac90-c14306b5e556"'
+			buildConfigField "String", "SDK_APP_TOKEN", '"7f64903d-4420-4cc3-ac90-c14306b5e556"'
 			applicationIdSuffix '.dev'
 		}
 		abn {
 			buildConfigField "String", "BASE_URL", '"https://www.cc-a.bit.admin.ch/app/verifier/v1/"'
-			buildConfigField "String", "SDK_API_KEY", '"f731fd3b-cb55-4cfd-9c46-fb3a927ffcd8"'
+			buildConfigField "String", "SDK_APP_TOKEN", '"f731fd3b-cb55-4cfd-9c46-fb3a927ffcd8"'
 			applicationIdSuffix '.abn'
 		}
 		prod {
 			buildConfigField "String", "BASE_URL", '"https://www.cc.bit.admin.ch/app/verifier/v1/"'
-			buildConfigField "String", "SDK_API_KEY", '"25958ed0-7790-4846-9341-7c7ef87ec389"'
+			buildConfigField "String", "SDK_APP_TOKEN", '"25958ed0-7790-4846-9341-7c7ef87ec389"'
 		}
 	}
 

--- a/verifier/src/main/java/ch/admin/bag/covidcertificate/verifier/MainApplication.kt
+++ b/verifier/src/main/java/ch/admin/bag/covidcertificate/verifier/MainApplication.kt
@@ -10,7 +10,7 @@ class MainApplication : Application() {
 
 	override fun onCreate() {
 		super.onCreate()
-		Config.apiKey = BuildConfig.SDK_API_KEY
+		Config.appToken = BuildConfig.SDK_APP_TOKEN
 		Config.userAgent =
 			UserAgentInterceptor.UserAgentGenerator { "${this.packageName};${BuildConfig.VERSION_NAME};${BuildConfig.BUILD_TIME};Android;${Build.VERSION.SDK_INT}" }
 

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -49,19 +49,21 @@ android {
 	}
 
 	productFlavors {
+		// These app tokens are reserved for the official COVID Certificate app.
+		// If you intend to integrate the CovidCertificate-SDK into your app, please get in touch with BIT/BAG to get a token assigned.
 		dev {
 			buildConfigField "String", "BASE_URL", '"https://www.cc-d.bit.admin.ch/app/wallet/v1/"'
-			buildConfigField "String", "SDK_API_KEY", '"c838a4c4-39e5-4bbb-8e75-e4382df2edfe"'
+			buildConfigField "String", "SDK_APP_TOKEN", '"c838a4c4-39e5-4bbb-8e75-e4382df2edfe"'
 			applicationIdSuffix '.dev'
 		}
 		abn {
 			buildConfigField "String", "BASE_URL", '"https://www.cc-a.bit.admin.ch/app/wallet/v1/"'
-			buildConfigField "String", "SDK_API_KEY", '"e9802c49-4f2b-49cc-a645-24c206366455"'
+			buildConfigField "String", "SDK_APP_TOKEN", '"e9802c49-4f2b-49cc-a645-24c206366455"'
 			applicationIdSuffix '.abn'
 		}
 		prod {
 			buildConfigField "String", "BASE_URL", '"https://www.cc.bit.admin.ch/app/wallet/v1/"'
-			buildConfigField "String", "SDK_API_KEY", '"0795dc8b-d8d0-4313-abf2-510b12d50939"'
+			buildConfigField "String", "SDK_APP_TOKEN", '"0795dc8b-d8d0-4313-abf2-510b12d50939"'
 		}
 	}
 

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/MainApplication.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/MainApplication.kt
@@ -10,7 +10,7 @@ class MainApplication : Application() {
 
 	override fun onCreate() {
 		super.onCreate()
-		Config.apiKey = BuildConfig.SDK_API_KEY
+		Config.appToken = BuildConfig.SDK_APP_TOKEN
 		Config.userAgent =
 			UserAgentInterceptor.UserAgentGenerator { "${this.packageName};${BuildConfig.VERSION_NAME};${BuildConfig.BUILD_TIME};Android;${Build.VERSION.SDK_INT}" }
 


### PR DESCRIPTION
To better represent what it does.

See the SDK PR here: https://github.com/admin-ch/CovidCertificate-SDK-Android/pull/22