### PR TITLE
Disable javascript in HtmlFragment

### DIFF
--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/html/HtmlFragment.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/html/HtmlFragment.kt
@@ -121,8 +121,6 @@ class HtmlFragment : Fragment() {
 				return true
 			}
 		}
-		val webSettings = web.settings
-		webSettings.javaScriptEnabled = true
 		if (data != null) {
 			data?.let { web.loadDataWithBaseURL(baseUrl, it, "text/html", "UTF-8", null) }
 		} else {


### PR DESCRIPTION
It's a leftover that is not needed. All HTML that we load is from the assets, and there is no JS anywhere.

Tested by clicking all the links in the imprint, all work as before and as expected. 