### PR TITLE
Added transfer worker for periodic certificate pulling in the background

### DIFF
--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/net/ConfigRepository.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/net/ConfigRepository.kt
@@ -39,6 +39,9 @@ class ConfigRepository private constructor(private val configSpec: ConfigSpec) {
 
 		private const val MIN_LOAD_WAIT_TIME = 60 * 60 * 1000L // 1h
 		private const val MAX_AGE_STATUS_VALID_CACHED_CONFIG = 48 * 60 * 60 * 1000L // 48h
+
+		fun getCurrentConfig(context: Context) =
+			ConfigSecureStorage.getInstance(context).getConfig() ?: AssetUtil.loadDefaultConfig(context)
 	}
 
 	private val configService: ConfigService

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -124,14 +124,15 @@ dependencies {
 	implementation 'androidx.fragment:fragment-ktx:1.3.3'
 	implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 	implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-	implementation "androidx.viewpager2:viewpager2:1.0.0"
+	implementation 'androidx.viewpager2:viewpager2:1.0.0'
 	implementation 'androidx.security:security-crypto:1.0.0'
+	implementation 'androidx.work:work-runtime-ktx:2.5.0'
 
 	implementation 'com.squareup.retrofit2:retrofit:2.9.0'
 	implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
 	implementation 'com.squareup.okhttp3:logging-interceptor:4.7.2'
 	implementation 'com.squareup.moshi:moshi:1.11.0'
-	kapt "com.squareup.moshi:moshi-kotlin-codegen:1.11.0"
+	kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.11.0'
 
 	testImplementation 'junit:junit:4.+'
 	androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/CertificatesViewModel.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/CertificatesViewModel.kt
@@ -171,11 +171,7 @@ class CertificatesViewModel(application: Application) : AndroidViewModel(applica
 							val qrCodeData = convertedCertificate.qrCodeData
 							val pdfData = convertedCertificate.pdfData
 							if (index == 0) {
-								val decodeState = CertificateDecoder.decode(qrCodeData)
-
-								if (decodeState is DecodeState.SUCCESS) {
-									walletDataStorage.replaceTransferCodeWithCertificate(transferCode, qrCodeData, pdfData)
-								}
+								walletDataStorage.replaceTransferCodeWithCertificate(transferCode, qrCodeData, pdfData)
 							} else {
 								walletDataStorage.saveWalletDataItem(WalletDataItem.CertificateWalletData(qrCodeData, pdfData))
 							}

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/transfercode/TransferCodeViewModel.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/transfercode/TransferCodeViewModel.kt
@@ -67,10 +67,9 @@ class TransferCodeViewModel(application: Application) : AndroidViewModel(applica
 							val qrCodeData = convertedCertificate.qrCodeData
 							val pdfData = convertedCertificate.pdfData
 							if (index == 0) {
+								walletDataStorage.replaceTransferCodeWithCertificate(transferCode, qrCodeData, pdfData)
 								val decodeState = CertificateDecoder.decode(qrCodeData)
-
 								if (decodeState is DecodeState.SUCCESS) {
-									walletDataStorage.replaceTransferCodeWithCertificate(transferCode, qrCodeData, pdfData)
 									conversionStateMutableLiveData.postValue(TransferCodeConversionState.CONVERTED(decodeState.dccHolder))
 								} else {
 									// The certificate returned from the server could not be decoded

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/transfercode/worker/TransferWorker.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/transfercode/worker/TransferWorker.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.wallet.transfercode.worker
+
+import android.content.Context
+import androidx.work.*
+import ch.admin.bag.covidcertificate.common.config.ConfigModel
+import ch.admin.bag.covidcertificate.wallet.BuildConfig
+import ch.admin.bag.covidcertificate.wallet.data.WalletDataItem
+import ch.admin.bag.covidcertificate.wallet.data.WalletDataSecureStorage
+import ch.admin.bag.covidcertificate.wallet.transfercode.logic.TransferCodeCrypto
+import ch.admin.bag.covidcertificate.wallet.transfercode.model.TransferCodeModel
+import ch.admin.bag.covidcertificate.wallet.transfercode.net.DeliveryRepository
+import ch.admin.bag.covidcertificate.wallet.transfercode.net.DeliverySpec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class TransferWorker(context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
+
+	companion object {
+		val WORKER_NAME = TransferWorker::class.java.canonicalName
+
+		private const val DEFAULT_REPEAT_INTERVAL = 120 * 60 * 1000L
+		private const val DEFAULT_FLEX_INTERVAL = 5 * 60 * 1000L
+		private const val DEFAULT_BACKOFF_DELAY = 30 * 1000L
+
+		fun scheduleTransferWorker(context: Context, config: ConfigModel? = null) {
+			val transferWorkRequest = PeriodicWorkRequest.Builder(
+				TransferWorker::class.java,
+				DEFAULT_REPEAT_INTERVAL,
+				TimeUnit.MILLISECONDS,
+				DEFAULT_FLEX_INTERVAL,
+				TimeUnit.MILLISECONDS
+			)
+				.setBackoffCriteria(BackoffPolicy.EXPONENTIAL, DEFAULT_BACKOFF_DELAY, TimeUnit.MILLISECONDS)
+				.build()
+
+			WorkManager.getInstance(context)
+				.enqueueUniquePeriodicWork(WORKER_NAME, ExistingPeriodicWorkPolicy.KEEP, transferWorkRequest)
+		}
+
+		fun cancelScheduledTransferWorker(context: Context) {
+			WorkManager.getInstance(context).cancelUniqueWork(WORKER_NAME)
+		}
+	}
+
+	private val walletDataStorage = WalletDataSecureStorage.getInstance(context)
+	private val deliveryRepository = DeliveryRepository.getInstance(DeliverySpec(context, BuildConfig.BASE_URL_DELIVERY))
+
+	private val workManager = WorkManager.getInstance(context)
+
+	override suspend fun doWork(): Result {
+		return withContext(Dispatchers.IO) {
+			val transferStates = walletDataStorage.getWalletData()
+				.filterIsInstance<WalletDataItem.TransferCodeWalletData>()
+				.map { transferCodeItem -> downloadTransferCertificate(transferCodeItem.transferCode) }
+				.toSet()
+
+			if (transferStates.contains(TransferState.ERROR)) {
+				return@withContext Result.retry()
+			} else if (!transferStates.contains(TransferState.NOT_AVAILABLE)) {
+				workManager.cancelUniqueWork(WORKER_NAME)
+			}
+			Result.success()
+		}
+	}
+
+	private suspend fun downloadTransferCertificate(transferCode: TransferCodeModel): TransferState {
+		val keyPair = TransferCodeCrypto.loadKeyPair(transferCode.code)
+
+		if (keyPair != null) {
+			try {
+				val decryptedCertificates = deliveryRepository.download(transferCode.code, keyPair)
+
+				return if (decryptedCertificates.isNotEmpty()) {
+					decryptedCertificates.forEachIndexed { index, convertedCertificate ->
+						val qrCodeData = convertedCertificate.qrCodeData
+						val pdfData = convertedCertificate.pdfData
+						if (index == 0) {
+							walletDataStorage.replaceTransferCodeWithCertificate(transferCode, qrCodeData, pdfData)
+						} else {
+							walletDataStorage.saveWalletDataItem(WalletDataItem.CertificateWalletData(qrCodeData, pdfData))
+						}
+
+						try {
+							deliveryRepository.complete(transferCode.code, keyPair)
+						} catch (e: IOException) {
+							// Best effort only
+						}
+					}
+					TransferState.SUCCESS
+				} else {
+					TransferState.NOT_AVAILABLE
+				}
+			} catch (e: IOException) {
+				return TransferState.ERROR
+			}
+		} else {
+			return TransferState.ERROR
+		}
+	}
+
+	private enum class TransferState {
+		SUCCESS,
+		NOT_AVAILABLE,
+		ERROR
+	}
+
+}


### PR DESCRIPTION
Added a periodic worker to regularly query for available certificates, if the wallet contains any transfer codes. The worker is started when hiding the app and cancelled on app start.