### PR TITLE
Fix pdf import on some devices

### DIFF
--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/qr/QRCodeReaderHelper.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/qr/QRCodeReaderHelper.kt
@@ -17,27 +17,26 @@ import android.graphics.Color
 import android.graphics.Rect
 import android.graphics.pdf.PdfRenderer
 import android.os.ParcelFileDescriptor
-import com.google.zxing.BinaryBitmap
-import com.google.zxing.ChecksumException
-import com.google.zxing.FormatException
-import com.google.zxing.LuminanceSource
-import com.google.zxing.MultiFormatReader
-import com.google.zxing.NotFoundException
-import com.google.zxing.RGBLuminanceSource
-import com.google.zxing.Result
+import com.google.zxing.*
 import com.google.zxing.common.HybridBinarizer
 import java.io.File
 import java.util.*
 
 object QRCodeReaderHelper {
 
+	private val hints = mapOf(
+		DecodeHintType.POSSIBLE_FORMATS to arrayListOf(BarcodeFormat.QR_CODE),
+		DecodeHintType.TRY_HARDER to true,
+	)
+	private val reader = MultiFormatReader().apply { setHints(hints) }
+
 	fun decodeQrCode(bitmap: Bitmap): String? {
 		var decoded: String? = null
+
 		val intArray = IntArray(bitmap.width * bitmap.height)
 		bitmap.getPixels(intArray, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
 		val source: LuminanceSource = RGBLuminanceSource(bitmap.width, bitmap.height, intArray)
 		val binaryBitmap = BinaryBitmap(HybridBinarizer(source))
-		val reader = MultiFormatReader()
 
 		try {
 			val result: Result = reader.decodeWithState(binaryBitmap)

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/add/CertificateAddFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/add/CertificateAddFragment.kt
@@ -32,9 +32,13 @@ class CertificateAddFragment : Fragment() {
 
 	companion object {
 		private const val ARG_CERTIFICATE = "ARG_CERTIFICATE"
+		private const val ARG_FROM_CAMERA = "ARG_FROM_CAMERA"
 
-		fun newInstance(certificate: DccHolder): CertificateAddFragment = CertificateAddFragment().apply {
-			arguments = bundleOf(ARG_CERTIFICATE to certificate)
+		fun newInstance(certificate: DccHolder, fromCamera: Boolean): CertificateAddFragment = CertificateAddFragment().apply {
+			arguments = bundleOf(
+				ARG_CERTIFICATE to certificate,
+				ARG_FROM_CAMERA to fromCamera,
+			)
 		}
 	}
 
@@ -44,12 +48,15 @@ class CertificateAddFragment : Fragment() {
 	private val binding get() = _binding!!
 
 	private lateinit var dccHolder: DccHolder
+	private var openedFragmentFromCamera: Boolean = false
 	private var isAlreadyAdded = false
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
+
 		dccHolder = (arguments?.getSerializable(ARG_CERTIFICATE) as? DccHolder)
-			?: throw IllegalStateException("Certificate detail fragment created without Certificate!")
+			?: throw IllegalStateException("CertificateAddFragment created without Certificate!")
+		openedFragmentFromCamera = arguments?.getBoolean(ARG_FROM_CAMERA) ?: throw IllegalStateException("Missing fromCamera!")
 		isAlreadyAdded = certificatesViewModel.containsCertificate(dccHolder.qrCodeData)
 	}
 
@@ -81,8 +88,13 @@ class CertificateAddFragment : Fragment() {
 				}
 			}
 		}
-		binding.certificateAddRetry.setOnClickListener {
-			parentFragmentManager.popBackStack()
+		if (openedFragmentFromCamera) {
+			binding.certificateAddRetry.isVisible = true
+			binding.certificateAddRetry.setOnClickListener {
+				parentFragmentManager.popBackStack()
+			}
+		} else {
+			binding.certificateAddRetry.isVisible = false
 		}
 
 	}

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/HomeFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/HomeFragment.kt
@@ -302,7 +302,7 @@ class HomeFragment : Fragment() {
 	private fun showCertificationAddFragment(dccHolder: DccHolder) {
 		parentFragmentManager.beginTransaction()
 			.setCustomAnimations(R.anim.slide_enter, R.anim.slide_exit, R.anim.slide_pop_enter, R.anim.slide_pop_exit)
-			.replace(R.id.fragment_container, CertificateAddFragment.newInstance(dccHolder))
+			.replace(R.id.fragment_container, CertificateAddFragment.newInstance(dccHolder, false))
 			.addToBackStack(CertificateAddFragment::class.java.canonicalName)
 			.commit()
 	}

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/pdf/PdfViewModel.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/pdf/PdfViewModel.kt
@@ -49,6 +49,7 @@ class PdfViewModel(application: Application) : AndroidViewModel(application) {
 				val inputStream: InputStream? = getApplication<Application>().contentResolver.openInputStream(uri)
 				val outputFile: File = File.createTempFile("certificate", ".pdf", getApplication<Application>().cacheDir)
 				inputStream?.copyTo(outputFile.outputStream())
+
 				val bitmaps = QRCodeReaderHelper.pdfToBitmap(getApplication<Application>(), outputFile)
 
 				for (bitmap in bitmaps) {

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/qr/WalletQrScanFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/qr/WalletQrScanFragment.kt
@@ -76,7 +76,7 @@ class WalletQrScanFragment : QrScanFragment() {
 	private fun showCertificationAddFragment(dccHolder: DccHolder) {
 		parentFragmentManager.beginTransaction()
 			.setCustomAnimations(R.anim.slide_enter, R.anim.slide_exit, R.anim.slide_pop_enter, R.anim.slide_pop_exit)
-			.replace(R.id.fragment_container, CertificateAddFragment.newInstance(dccHolder))
+			.replace(R.id.fragment_container, CertificateAddFragment.newInstance(dccHolder, true))
 			.addToBackStack(CertificateAddFragment::class.java.canonicalName)
 			.commit()
 	}


### PR DESCRIPTION
Attempt to fix the issues with PDF import on some devices with the new, more dense PDFs. Just try harder ;)

While I'm at it, also hide the "Scan again" button when the CertificateAddFragment was opened via a deeplink or PDF import.