### PR TITLE
Transfer Certificate Detail Error Indicator

### DIFF
--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/transfercode/view/TransferCodeBubbleView.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/transfercode/view/TransferCodeBubbleView.kt
@@ -137,13 +137,13 @@ class TransferCodeBubbleView @JvmOverloads constructor(
 		}
 
 		state.error?.let {
-			binding.transferCodeErrorIcon.isVisible = true
 			if (it.code == ErrorCodes.GENERAL_OFFLINE) {
 				binding.transferCodeErrorIcon.setImageResource(R.drawable.ic_corner_offline)
 			} else {
 				binding.transferCodeErrorIcon.setImageResource(R.drawable.ic_corner_process_error)
 			}
 		}
+		binding.transferCodeErrorIcon.isVisible = state.error != null
 
 		binding.transferCodeValue.setTransferCode(transferCode.code)
 

--- a/wallet/src/main/res/layout/view_transfer_code_waiting.xml
+++ b/wallet/src/main/res/layout/view_transfer_code_waiting.xml
@@ -20,6 +20,8 @@
 		android:layout_width="0dp"
 		android:layout_height="0dp"
 		android:adjustViewBounds="true"
+		android:alpha="0"
+		tools:alpha="1"
 		app:layout_constraintBottom_toBottomOf="@+id/illu_transfer_code_waiting_phone"
 		app:layout_constraintEnd_toEndOf="@+id/illu_transfer_code_waiting_phone"
 		app:layout_constraintStart_toStartOf="@+id/illu_transfer_code_waiting_phone"


### PR DESCRIPTION
Fix initial state of ripple in transfer illu and the transfer detail error indicator is now correctly removed after successful retry