### PR TITLE
Fix networking only once onboarding is completed

### DIFF
--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/MainActivity.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : AppCompatActivity() {
 	private var forceUpdateDialog: AlertDialog? = null
 	private var isIntentConsumed = false
 
-	private val onAndUpdateBoardingLauncher =
+	private val onboardingLauncher =
 		registerForActivityResult(StartActivityForResult()) { activityResult: ActivityResult ->
 			if (activityResult.resultCode == RESULT_OK) {
 				secureStorage.setOnboardingCompleted(true)
@@ -68,15 +68,13 @@ class MainActivity : AppCompatActivity() {
 		if (savedInstanceState == null) {
 			val onboardingCompleted: Boolean = secureStorage.getOnboardingCompleted()
 			if (!onboardingCompleted) {
-				onAndUpdateBoardingLauncher.launch(Intent(this, OnboardingActivity::class.java))
+				onboardingLauncher.launch(Intent(this, OnboardingActivity::class.java))
 			} else {
 				showHomeFragment()
 			}
 		}
 
 		configViewModel.configLiveData.observe(this) { config -> handleConfig(config) }
-
-		CovidCertificateSdk.registerWithLifecycle(lifecycle)
 
 		if (savedInstanceState != null) {
 			isIntentConsumed = savedInstanceState.getBoolean(KEY_IS_INTENT_CONSUMED)
@@ -99,18 +97,14 @@ class MainActivity : AppCompatActivity() {
 		outState.putBoolean(KEY_IS_INTENT_CONSUMED, isIntentConsumed)
 	}
 
-	override fun onStart() {
-		super.onStart()
-		configViewModel.loadConfig(BuildConfig.BASE_URL, BuildConfig.VERSION_NAME, BuildConfig.BUILD_TIME.toString())
-		CovidCertificateSdk.getCertificateVerificationController().refreshTrustList(lifecycleScope)
-	}
-
 	override fun onDestroy() {
 		super.onDestroy()
 		CovidCertificateSdk.unregisterWithLifecycle(lifecycle)
 	}
 
 	private fun showHomeFragment() {
+		CovidCertificateSdk.registerWithLifecycle(lifecycle)
+
 		supportFragmentManager.beginTransaction()
 			.add(R.id.fragment_container, HomeFragment.newInstance())
 			.commit()

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/HomeFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/HomeFragment.kt
@@ -23,6 +23,7 @@ import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import ch.admin.bag.covidcertificate.common.config.ConfigViewModel
@@ -37,6 +38,7 @@ import ch.admin.bag.covidcertificate.common.util.setSecureFlagToBlockScreenshots
 import ch.admin.bag.covidcertificate.common.views.hideAnimated
 import ch.admin.bag.covidcertificate.common.views.rotate
 import ch.admin.bag.covidcertificate.common.views.showAnimated
+import ch.admin.bag.covidcertificate.eval.CovidCertificateSdk
 import ch.admin.bag.covidcertificate.eval.data.state.DecodeState
 import ch.admin.bag.covidcertificate.eval.models.DccHolder
 import ch.admin.bag.covidcertificate.wallet.BuildConfig
@@ -99,6 +101,12 @@ class HomeFragment : Fragment() {
 		setupPager()
 		setupInfoBox()
 		setupImportObservers()
+	}
+
+	override fun onStart() {
+		super.onStart()
+		configViewModel.loadConfig(BuildConfig.BASE_URL, BuildConfig.VERSION_NAME, BuildConfig.BUILD_TIME.toString())
+		CovidCertificateSdk.getCertificateVerificationController().refreshTrustList(lifecycleScope)
 	}
 
 	override fun onResume() {


### PR DESCRIPTION
- Moving the `CovidCertificateSdk.registerWithLifecycle` to `showHomeFragment` to easily cover both paths there (onboarding activity finished or was already completed days ago).
- Moving the trustlist refresh and config loading to the HomeFragment, since that is one-shot and even though the fragment's lifecycleScope is different from the activity's, this should still be enough.
