### PR TITLE
Certificate Light Bitmap Filtering

### DIFF
--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
@@ -105,7 +105,7 @@ class CertificateLightDetailFragment : Fragment(R.layout.fragment_certificate_li
 	private fun displayQrCode() {
 		val decoded = qrCodeImage.fromBase64()
 		val qrCodeBitmap = BitmapFactory.decodeByteArray(decoded, 0, decoded.size)
-		val qrCodeDrawable = BitmapDrawable(resources, qrCodeBitmap).apply { isFilterBitmap = false }
+		val qrCodeDrawable = BitmapDrawable(resources, qrCodeBitmap)
 		binding.certificateLightDetailQrCode.setImageDrawable(qrCodeDrawable)
 	}
 

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightPagerFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightPagerFragment.kt
@@ -108,7 +108,7 @@ class CertificateLightPagerFragment : Fragment(R.layout.fragment_certificate_lig
 	private fun displayQrCode() {
 		val decoded = qrCodeImage.fromBase64()
 		val qrCodeBitmap = BitmapFactory.decodeByteArray(decoded, 0, decoded.size)
-		val qrCodeDrawable = BitmapDrawable(resources, qrCodeBitmap).apply { isFilterBitmap = false }
+		val qrCodeDrawable = BitmapDrawable(resources, qrCodeBitmap)
 		binding.certificatePageQrCode.setImageDrawable(qrCodeDrawable)
 	}
 


### PR DESCRIPTION
Remove bitmap filtering for certificate light QR codes because they are big enough and aren't scaled up