### PR TITLE
Removed PDF to bitmap scaling

### DIFF
--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/qr/QRCodeReaderHelper.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/qr/QRCodeReaderHelper.kt
@@ -61,16 +61,19 @@ object QRCodeReaderHelper {
 
 			for (i in 0 until min(pageCount, 5)) {
 				val page: PdfRenderer.Page = renderer.openPage(i)
-				val width = context.resources.displayMetrics.densityDpi / 72 * page.width
-				val height = context.resources.displayMetrics.densityDpi / 72 * page.height
+				//val width = context.resources.displayMetrics.densityDpi / 72 * page.width
+				val width = page.width
+				//val height = context.resources.displayMetrics.densityDpi / 72 * page.height
+				val height = page.height
 				bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
 
 				val canvas = Canvas(bitmap)
 				canvas.drawColor(Color.WHITE)
 				canvas.drawBitmap(bitmap, 0.0f, 0.0f, null)
 
-				val r = Rect(0, 0, width, height)
-				page.render(bitmap, r, null, PdfRenderer.Page.RENDER_MODE_FOR_PRINT)
+				//val r = Rect(0, 0, width, height)
+				//page.render(bitmap, r, null, PdfRenderer.Page.RENDER_MODE_FOR_PRINT)
+				page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_PRINT)
 				bitmaps.add(bitmap)
 
 				page.close()


### PR DESCRIPTION
When PDF is scaled up during bitmap rendering, the QR code position markers are sometimes warped which results in 'NO_CODE_FOUND'.

Fixes #203 