### PR TITLE
Show nice chooser to share PDF

### DIFF
--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/pdf/export/PdfExportShareContract.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/pdf/export/PdfExportShareContract.kt
@@ -22,11 +22,12 @@ class PdfExportShareContract : ActivityResultContract<Uri, Uri>() {
 
 	override fun createIntent(context: Context, input: Uri?): Intent {
 		this.uri = input
-		return Intent(Intent.ACTION_SEND).apply {
+		val intent = Intent(Intent.ACTION_SEND).apply {
 			type = "application/pdf"
 			putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.wallet_certificate))
 			putExtra(Intent.EXTRA_STREAM, input)
 		}
+		return Intent.createChooser(intent, null)
 	}
 
 	override fun parseResult(resultCode: Int, intent: Intent?): Uri? {


### PR DESCRIPTION
Use Android's [share sheet](https://developer.android.com/training/sharing/send#why-to-use-system-sharesheet) for exporting the PDF. Using ACTION_CHOOSER also matches nicely with what [it's intended for](https://developer.android.com/reference/android/content/Intent#ACTION_CHOOSER).

Pro:
- You always get a chooser. If you click "Always" in the old version, you're in trouble.
- You get more/better suggestions for contacts/apps
- It looks nicer because Android opens it only to 2/3 of the screensize

Con:
- Slightly worse usage of space (more entries, 10 vs 12, but less apps)
- Android doesn't preview PDFs :(

| Before | After |
| --- | --- |
|  <img src=https://user-images.githubusercontent.com/56064810/130361907-a740fe74-6240-4af5-a66a-41ca0add5506.png width=300px> |  <img src=https://user-images.githubusercontent.com/56064810/130361903-22ff72b2-f81d-459d-83c2-08e85f6fdf45.png width=300px> |

Don't ask me why VLC is registering to receive `application/pdf` 😂 
