### PR TITLE
Proposal self validation "Have the button simply not trigger the green checkmark animation" #295

### DIFF
--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -388,11 +388,11 @@ Schweiz"</string>
     <!-- "Bis" Label im Zertifikats-Detail -->
     <string name="wallet_certificate_valid_until">"bis"</string>
 
-    <!-- Message im Zertifikatsdetail während Überprüfung -->
-    <string name="wallet_certificate_verifying">"Das Zertifikat wird geprüft"</string>
+    <!-- Message im Zertifikatsdetail während Aktualisierung -->
+    <string name="wallet_certificate_refresh">"Das Zertifikat wird aktualisiert"</string>
 
-    <!-- Message nach erfolgreicher Prüfung im Zertifikatdetail -->
-    <string name="wallet_certificate_verify_success">"Prüfung erfolgreich"</string>
+    <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
+    <string name="wallet_certificate_refresh_success">"Aktualisierung erfolgreich"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Information"</string>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -392,7 +392,7 @@ Schweiz"</string>
     <string name="wallet_certificate_refresh">"Das Zertifikat wird aktualisiert"</string>
 
     <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
-    <string name="wallet_certificate_refresh_success">"Aktualisierung erfolgreich"</string>
+    <string name="wallet_certificate_refresh_success">"Aktualisiert"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Information"</string>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -386,11 +386,11 @@ Suisse"</string>
     <!-- "Bis" Label im Zertifikats-Detail -->
     <string name="wallet_certificate_valid_until">"jusqu'au"</string>
 
-    <!-- Message im Zertifikatsdetail während Überprüfung -->
-    <string name="wallet_certificate_verifying">"Certificat en cours de vérification"</string>
+    <!-- Message im Zertifikatsdetail während Aktualisierung -->
+    <string name="wallet_certificate_refresh">"Certificat en cours d'actualisation"</string>
 
-    <!-- Message nach erfolgreicher Prüfung im Zertifikatdetail -->
-    <string name="wallet_certificate_verify_success">"Vérification réussie"</string>
+    <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
+    <string name="wallet_certificate_refresh_success">"Actualisation réussie"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Information"</string>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -390,7 +390,7 @@ Suisse"</string>
     <string name="wallet_certificate_refresh">"Certificat en cours d'actualisation"</string>
 
     <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
-    <string name="wallet_certificate_refresh_success">"Actualisation réussie"</string>
+    <string name="wallet_certificate_refresh_success">"Actualisé"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Information"</string>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -392,7 +392,7 @@ Svizzera"</string>
     <string name="wallet_certificate_refresh">"Il certificato è in fase di aggiornamento"</string>
 
     <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
-    <string name="wallet_certificate_refresh_success">"Aggiornamento effettuata con successo"</string>
+    <string name="wallet_certificate_refresh_success">"Aggiornamento"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Informazione"</string>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -388,11 +388,11 @@ Svizzera"</string>
     <!-- "Bis" Label im Zertifikats-Detail -->
     <string name="wallet_certificate_valid_until">"fino al"</string>
 
-    <!-- Message im Zertifikatsdetail während Überprüfung -->
-    <string name="wallet_certificate_verifying">"Verifica del certificato in corso"</string>
+    <!-- Message im Zertifikatsdetail während Aktualisierung -->
+    <string name="wallet_certificate_refresh">"Il certificato è in fase di aggiornamento"</string>
 
-    <!-- Message nach erfolgreicher Prüfung im Zertifikatdetail -->
-    <string name="wallet_certificate_verify_success">"Verifica effettuata con successo"</string>
+    <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
+    <string name="wallet_certificate_refresh_success">"Aggiornamento effettuata con successo"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Informazione"</string>

--- a/common/src/main/res/values-rm/strings.xml
+++ b/common/src/main/res/values-rm/strings.xml
@@ -384,11 +384,11 @@ signatura nunvalaivla"</string>
     <!-- "Bis" Label im Zertifikats-Detail -->
     <string name="wallet_certificate_valid_until">"fin ils"</string>
 
-    <!-- Message im Zertifikatsdetail während Überprüfung -->
-    <string name="wallet_certificate_verifying">"Il certificat vegn verifitgà"</string>
+    <!-- Message im Zertifikatsdetail während Aktualisierung -->
+    <string name="wallet_certificate_refresh">"Il certificat vegn actualisada"</string>
 
-    <!-- Message nach erfolgreicher Prüfung im Zertifikatdetail -->
-    <string name="wallet_certificate_verify_success">"Verificaziun reussida"</string>
+    <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
+    <string name="wallet_certificate_refresh_success">"Actualisada reussida"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Infurmaziun"</string>

--- a/common/src/main/res/values-rm/strings.xml
+++ b/common/src/main/res/values-rm/strings.xml
@@ -388,7 +388,7 @@ signatura nunvalaivla"</string>
     <string name="wallet_certificate_refresh">"Il certificat vegn actualisada"</string>
 
     <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
-    <string name="wallet_certificate_refresh_success">"Actualisada reussida"</string>
+    <string name="wallet_certificate_refresh_success">"Actualisada"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Infurmaziun"</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -387,11 +387,11 @@ Switzerland"</string>
     <!-- "Bis" Label im Zertifikats-Detail -->
     <string name="wallet_certificate_valid_until">"until"</string>
 
-    <!-- Message im Zertifikatsdetail während Überprüfung -->
-    <string name="wallet_certificate_verifying">"The certificate is being verified"</string>
+    <!-- Message im Zertifikatsdetail während Aktualisierung -->
+    <string name="wallet_certificate_refresh">"The certificate is being refreshed"</string>
 
-    <!-- Message nach erfolgreicher Prüfung im Zertifikatdetail -->
-    <string name="wallet_certificate_verify_success">"Verification successful"</string>
+    <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
+    <string name="wallet_certificate_refresh_success">"Refresh successful"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Information"</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -391,7 +391,7 @@ Switzerland"</string>
     <string name="wallet_certificate_refresh">"The certificate is being refreshed"</string>
 
     <!-- Message nach erfolgreicher Aktualisierung im Zertifikatdetail -->
-    <string name="wallet_certificate_refresh_success">"Refresh successful"</string>
+    <string name="wallet_certificate_refresh_success">"Refreshed"</string>
 
     <!-- Accessibility: Info Box Butto -->
     <string name="accessibility_info_box">"Information"</string>

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
@@ -267,10 +267,9 @@ class CertificateDetailFragment : Fragment() {
 		setInfoBubbleBackgrounds(R.color.greyish, R.color.greyish)
 		updateConversionButtons(isLightCertificateEnabled = false, isPdfExportEnabled = false)
 
-		val info = SpannableString(context.getString(R.string.wallet_certificate_verifying))
+		val info = SpannableString(context.getString(R.string.wallet_certificate_refresh))
 		if (isForceValidate) {
 			showStatusInfoAndDescription(null, info, 0)
-			showForceValidation(R.color.grey, 0, 0, info)
 		} else {
 			showStatusInfoAndDescription(null, info, 0)
 		}
@@ -283,17 +282,16 @@ class CertificateDetailFragment : Fragment() {
 		binding.certificateDetailInfoValidityGroup.isVisible = true
 		binding.certificateDetailErrorCode.isVisible = false
 		showValidityDate(state.validityRange?.validUntil, certificateHolder.certType, state)
-		setInfoBubbleBackgrounds(R.color.blueish, R.color.greenish)
+		setInfoBubbleBackgrounds(R.color.blueish, R.color.blueish)
 
 		// Certificate Light and PDF export is enabled for a valid certificate that was issued in Switzerland
 		val isIssuedInSwitzerland = ISSUER_SWITZERLAND.contains(certificateHolder.issuer)
 		updateConversionButtons(isLightCertificateEnabled = isIssuedInSwitzerland, isPdfExportEnabled = isIssuedInSwitzerland)
 
 		val info = SpannableString(context.getString(R.string.verifier_verify_success_info))
-		val forceValidationInfo = context.getString(R.string.wallet_certificate_verify_success).makeBold()
+		val forceValidationInfo = context.getString(R.string.wallet_certificate_refresh_success).makeBold()
 		if (isForceValidate) {
-			showStatusInfoAndDescription(null, forceValidationInfo, R.drawable.ic_check_green)
-			showForceValidation(R.color.green, R.drawable.ic_check_green, R.drawable.ic_check_large, forceValidationInfo)
+			showStatusInfoAndDescription(null, forceValidationInfo, R.drawable.ic_check_grey)
 			readjustStatusDelayed(R.color.blueish, R.drawable.ic_info_blue, info)
 		} else {
 			showStatusInfoAndDescription(null, info, R.drawable.ic_info_blue)

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
@@ -18,7 +18,6 @@ import android.text.SpannableString
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AlertDialog
@@ -66,7 +65,6 @@ class CertificateDetailFragment : Fragment() {
 
 	companion object {
 		private const val STATUS_HIDE_DELAY = 2000L
-		private const val STATUS_LOAD_DELAY = 1000L
 
 		private const val ARG_CERTIFICATE = "ARG_CERTIFICATE"
 
@@ -138,18 +136,6 @@ class CertificateDetailFragment : Fragment() {
 				.create()
 				.show()
 		}
-
-		binding.certificateDetailButtonReverify.setOnClickListener {
-			binding.certificateDetailButtonReverify.hideAnimated()
-			binding.scrollview.smoothScrollTo(0, 0)
-			isForceValidate = true
-			hideDelayedJob?.cancel()
-			certificatesViewModel.startVerification(
-				certificateHolder,
-				delayInMillis = STATUS_LOAD_DELAY,
-				isForceVerification = true
-			)
-		}
 	}
 
 	override fun onResume() {
@@ -204,7 +190,6 @@ class CertificateDetailFragment : Fragment() {
 		certificatesViewModel.statefulWalletItems.observe(viewLifecycleOwner) { items ->
 			items.filterIsInstance(StatefulWalletItem.VerifiedCertificate::class.java)
 				.find { it.certificateHolder?.qrCodeData == certificateHolder.qrCodeData }?.let {
-					binding.certificateDetailButtonReverify.showAnimated()
 					updateStatusInfo(it.state)
 				}
 		}
@@ -560,7 +545,6 @@ class CertificateDetailFragment : Fragment() {
 
 			binding.certificateDetailStatusIcon.setImageResource(statusIconId)
 
-			binding.certificateDetailButtonReverify.showAnimated()
 			isForceValidate = false
 		}
 	}

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/pager/CertificatePagerFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/pager/CertificatePagerFragment.kt
@@ -136,7 +136,7 @@ class CertificatePagerFragment : Fragment() {
 		showLoadingIndicator(true)
 		setInfoBubbleBackground(R.color.greyish)
 		binding.certificatePageStatusIcon.setImageResource(0)
-		binding.certificatePageInfo.text = SpannableString(context.getString(R.string.wallet_certificate_verifying))
+		binding.certificatePageInfo.text = SpannableString(context.getString(R.string.wallet_certificate_refresh))
 	}
 
 	private fun displaySuccessState() {

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
@@ -181,7 +181,7 @@ class CertificateLightDetailFragment : Fragment(R.layout.fragment_certificate_li
 	private fun displayLoadingState() {
 		showLoadingIndicator(true)
 		setVerificationStateBubbleColor(R.color.greyish)
-		binding.certificateLightDetailVerificationStatus.setText(R.string.wallet_certificate_verifying)
+		binding.certificateLightDetailVerificationStatus.setText(R.string.wallet_certificate_refresh)
 	}
 
 	private fun displaySuccessState() {

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightPagerFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightPagerFragment.kt
@@ -171,7 +171,7 @@ class CertificateLightPagerFragment : Fragment(R.layout.fragment_certificate_lig
 	private fun displayLoadingState() {
 		showLoadingIndicator(true)
 		setVerificationStateBubbleColor(R.color.greyish)
-		binding.certificatePageStatusInfo.setText(R.string.wallet_certificate_verifying)
+		binding.certificatePageStatusInfo.setText(R.string.wallet_certificate_refresh)
 
 	}
 

--- a/wallet/src/main/res/layout/fragment_certificate_detail.xml
+++ b/wallet/src/main/res/layout/fragment_certificate_detail.xml
@@ -442,17 +442,6 @@
 
 			</androidx.core.widget.NestedScrollView>
 
-			<ImageButton
-				android:id="@+id/certificate_detail_button_reverify"
-				style="@style/CovidCertificate.FloatingImageButton"
-				android:layout_width="@dimen/floating_button_height"
-				android:layout_height="@dimen/floating_button_height"
-				android:layout_gravity="bottom|end"
-				android:layout_marginEnd="@dimen/spacing_very_large"
-				android:layout_marginBottom="@dimen/spacing_very_large"
-				android:elevation="@dimen/floating_button_elevation"
-				app:srcCompat="@drawable/ic_load" />
-
 		</FrameLayout>
 
 	</LinearLayout>


### PR DESCRIPTION
* Similar to refresh on startup of the app
  * Change wallet_certificate_verifying to wallet_certificate_refresh
  * Animation only on the InfoMessage
  * Nothing on the QR-Code itself
* Drop the option and button for the End User
* Todo: Code and translations review