### PR TITLE
Add prodfdroid build flavour

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -32,6 +32,9 @@ android {
 		dev {}
 		abn {}
 		prod {}
+		prodfdroid {
+			minSdkVersion 24
+		}
 	}
 
 	flavorDimensions "version"

--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/util/EnvironmentUtil.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/util/EnvironmentUtil.kt
@@ -19,6 +19,7 @@ object EnvironmentUtil {
 		"dev" -> SdkEnvironment.DEV
 		"abn" -> SdkEnvironment.ABN
 		"prod" -> SdkEnvironment.PROD
+		"prodfdroid" -> SdkEnvironment.PROD
 		else -> throw IllegalArgumentException("Unknown environment $flavor")
 	}
 

--- a/common/src/prodfdroid/java/ch/admin/bag/covidcertificate/common/debug/DebugFragment.kt
+++ b/common/src/prodfdroid/java/ch/admin/bag/covidcertificate/common/debug/DebugFragment.kt
@@ -1,0 +1,25 @@
+package ch.admin.bag.covidcertificate.common.debug
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import android.content.Context
+import androidx.fragment.app.Fragment
+
+open class DebugFragment : Fragment() {
+
+	companion object {
+		fun newInstance(): DebugFragment = DebugFragment()
+
+		const val EXISTS = false
+
+		fun initDebug(context: Context) {}
+	}
+
+}

--- a/verifier/build.gradle
+++ b/verifier/build.gradle
@@ -68,6 +68,11 @@ android {
 			buildConfigField "String", "BASE_URL", '"https://www.cc.bit.admin.ch/app/verifier/v1/"'
 			buildConfigField "String", "SDK_APP_TOKEN", '"25958ed0-7790-4846-9341-7c7ef87ec389"'
 		}
+		prodfdroid {
+			minSdkVersion 24
+			buildConfigField "String", "BASE_URL", '"https://www.cc.bit.admin.ch/app/verifier/v1/"'
+			buildConfigField "String", "SDK_APP_TOKEN", '"25958ed0-7790-4846-9341-7c7ef87ec389"'
+		}
 	}
 
 	flavorDimensions "version"

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -74,6 +74,13 @@ android {
 			buildConfigField "String", "BASE_URL_TRANSFORMATION", '"https://covidcertificate-app.bit.admin.ch/app/transform/v1/"'
 			buildConfigField "String", "SDK_APP_TOKEN", '"0795dc8b-d8d0-4313-abf2-510b12d50939"'
 		}
+		prodfdroid {
+			minSdkVersion 24
+			buildConfigField "String", "BASE_URL", '"https://www.cc.bit.admin.ch/app/wallet/v1/"'
+			buildConfigField "String", "BASE_URL_DELIVERY", '"https://covidcertificate-app.bit.admin.ch/app/delivery/v1/"'
+			buildConfigField "String", "BASE_URL_TRANSFORMATION", '"https://covidcertificate-app.bit.admin.ch/app/transform/v1/"'
+			buildConfigField "String", "SDK_APP_TOKEN", '"0795dc8b-d8d0-4313-abf2-510b12d50939"'
+		}
 	}
 
 	flavorDimensions "version"

--- a/wallet/src/prodfdroid/java/ch/admin/bag/covidcertificate/wallet/debug/WalletDebugFragment.kt
+++ b/wallet/src/prodfdroid/java/ch/admin/bag/covidcertificate/wallet/debug/WalletDebugFragment.kt
@@ -1,0 +1,19 @@
+package ch.admin.bag.covidcertificate.wallet.debug
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+import ch.admin.bag.covidcertificate.common.debug.DebugFragment
+
+class WalletDebugFragment : DebugFragment() {
+	companion object {
+		fun newInstance(): DebugFragment = DebugFragment()
+	}
+}


### PR DESCRIPTION
This copies everything from prod, but raises the minSdkVersion to 24.
See https://github.com/admin-ch/CovidCertificate-App-Android/issues/304.
Build it with `./gradlew wallet:assembleProdfdroidRelease`.