### PR TITLE
Improve PDF import error message

### DIFF
--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/HomeFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/HomeFragment.kt
@@ -355,9 +355,9 @@ class HomeFragment : Fragment() {
 	}
 
 	private fun showImportError(errorCode: String) {
-		val message = getString(R.string.verifier_error_invalid_format) + " ($errorCode)"
+		val message = getString(R.string.error_file_import_text) + " ($errorCode)"
 		AlertDialog.Builder(requireContext(), R.style.CovidCertificate_AlertDialogStyle)
-			.setTitle(R.string.error_title)
+			.setTitle(R.string.error_file_import_title)
 			.setMessage(message)
 			.setPositiveButton(R.string.ok_button) { dialog, _ ->
 				dialog.dismiss()

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/pdf/PdfViewModel.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/pdf/PdfViewModel.kt
@@ -58,7 +58,7 @@ class PdfViewModel(application: Application) : AndroidViewModel(application) {
 	fun importPdf(clipData: ClipData) {
 		if (clipData.itemCount != 1 || clipData.getItemAt(0) == null || clipData.getItemAt(0).uri == null) {
 			pdfImportMutableLiveData.postValue(
-				PdfImportState.DONE(DecodeState.ERROR(StateError(PdfErrorCodes.FAILED_TO_READ, "The PDF was not be imported")))
+				PdfImportState.DONE(DecodeState.ERROR(StateError(PdfErrorCodes.FAILED_TO_READ, "The PDF was not imported")))
 			)
 			return
 		}


### PR DESCRIPTION
Previously if the PDF import failed the error text said "Invalid format". This confused a few people who were trying to import correct PDFs, but for which ZXing failed to find the QR code.

This PR improves the error message to give a better - albeit somewhat generic - reason ("either wrong QR code or QR code could not be found").