### PR TITLE
Improve build scripts

### DIFF
--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -13,7 +13,7 @@ Download and install [Docker](https://www.docker.com/).
 ```shell
 git clone https://github.com/admin-ch/CovidCertificate-App-Android.git ~/CovidCertificate-App-Android
 cd ~/CovidCertificate-App-Android
-git checkout 1.0.0
+git checkout release/version-1.0.0
 ```
 
 ## Wallet App
@@ -28,12 +28,14 @@ git checkout 1.0.0
 ### Build the Wallet app using Docker
 
 1. Build a Docker Image with the required Android Tools
-2. Build the App in the Docker Container while specifying the build timestamp that was recorded earlier (e.g., 1595936711208)
-3. Copy the freshly-built APK
+2. Generate a dummy key store for signing
+3. Build the App in the Docker Container while specifying the build timestamp that was recorded earlier (e.g., 1595936711208)
+4. Copy the freshly-built APK
 
 ```shell
 cd ~/CovidCertificate-App-Android
 docker build -t covidcertificate-builder .
+docker run --rm -v ~/CovidCertificate-App-Android:/home/covidcertificate -w /home/covidcertificate covidcertificate-builder keytool -genkeypair -storepass securePassword -keypass securePassword -alias keyAlias -keyalg RSA -keystore wallet/build.keystore -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown'
 docker run --rm -v ~/CovidCertificate-App-Android:/home/covidcertificate -w /home/covidcertificate covidcertificate-builder gradle wallet:assembleProdRelease -PkeystorePassword=securePassword -PkeyAlias=keyAlias -PkeyAliasPassword=securePassword -PkeystoreFile=build.keystore -PbuildTimestamp=1622186583268
 cp wallet/build/outputs/apk/prod/release/wallet-prod-release.apk wallet-built.apk
 ```
@@ -78,12 +80,14 @@ python ../apkdiff.py wallet-built.apk wallet-store.apk
 ### Build the Verifier app using Docker
 
 1. Build a Docker Image with the required Android Tools
-2. Build the App in the Docker Container while specifying the build timestamp that was recorded earlier (e.g., 1595936711208)
-3. Copy the freshly-built APK
+2. Generate a dummy key store for signing
+3. Build the App in the Docker Container while specifying the build timestamp that was recorded earlier (e.g., 1595936711208)
+4. Copy the freshly-built APK
 
 ```shell
 cd ~/CovidCertificate-App-Android
 docker build -t covidcertificate-builder .
+docker run --rm -v ~/CovidCertificate-App-Android:/home/covidcertificate -w /home/covidcertificate covidcertificate-builder keytool -genkeypair -storepass securePassword -keypass securePassword -alias keyAlias -keyalg RSA -keystore wallet/build.keystore -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown'
 docker run --rm -v ~/CovidCertificate-App-Android:/home/covidcertificate -w /home/covidcertificate covidcertificate-builder gradle verifier:assembleProdRelease -PkeystorePassword=securePassword -PkeyAlias=keyAlias -PkeyAliasPassword=securePassword -PkeystoreFile=build.keystore -PbuildTimestamp=1622186583268
 cp verifier/build/outputs/apk/prod/release/verifier-prod-release.apk verifier-built.apk
 ```

--- a/buildAndCompare.sh
+++ b/buildAndCompare.sh
@@ -1,38 +1,99 @@
 #!/bin/bash
-set -e
+
+# Script to automate the building and comparing of the CovidCertificate apps
+#
+# The first and only argument should be the path to the APK to be compared.
+
+set -eu
 
 if [[ $# -ne 1 ]]; then
   echo "Pass the path/to/store.apk as an argument!"
   exit 1
 fi
+referenceApk=$1
 
 echo "Which app would you like to build ('wallet' or 'verifier')?"
 read appName
 
-echo "Please enter the keystore filename:"
-read keystoreFile
+echo "Do you want to provide a keystore [Yn]?"
+read willProvideKeystore
 
-echo "Please enter the keystore password:"
-read -s keystorePassword
+case "$willProvideKeystore" in
+  # Case 1: Autogenerate a dummy keystore
+  [nN][oO]|[nN])
+  echo "[WARNING] Auto-generating a dummy keystore with default credentials. Do NOT use the resulting APK!"
+  rm -f "$appName"/insecure.keystore
+  keytool -genkeypair -storepass password -keypass password -alias keyAlias -keyalg RSA -keystore "$appName"/insecure.keystore -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown'
+  keystoreFile="$appName"/insecure.keystore
+  keystorePassword=password
+  keyAlias=keyAlias
+  keyAliasPassword=keyAliasPassword
+  ;;
 
-echo "Please enter the keyAlias:"
-read keyAlias
+  # Case 2: Let the user choose a keystore
+  *)
+  echo "Please enter the keystore filename (e.g. wallet/build.keystore):"
+  read keystoreFile
 
-echo "Please enter the keyAlias password:"
-read -s keyAliasPassword
+  echo "Please enter the keystore password:"
+  read -s keystorePassword
 
-echo "Please enter the build timestamp:"
+  echo "Please enter the keyAlias:"
+  read keyAlias
+
+  echo "Please enter the keyAlias password:"
+  read -s keyAliasPassword
+  ;;
+esac
+
+echo "Please enter the build timestamp (e.g. 1622186583268):"
 read buildTimestamp
 
-echo "Branch (e.g. release/version-1.0.0)":
-read branch
+# This is necessary because Ubique's gradle plugin will automatically set the branch.
+# Here we want to override it in order to reproduce the build.
+echo "Please enter the branch off which the release was build (e.g. release/version-1.0.0):"
+read buildBranch
+
+echo "Please enter the git tag (e.g. v2.7.0-2700-wallet) or branch (e.g. release/version-1.0.0) to be reproduced."
+echo "This is what will be checked out and reproduced."
+read tree
+
+echo "Do you want to build the F-Droid version [yN]?"
+read fdroid
+
+# Set gradle task to be run
+case "$fdroid" in
+  [yY][eE][sS]|[yY])
+  gradletask="$appName":assembleProdfdroidRelease
+  ;;
+
+  *)
+  gradletask="$appName":assembleProdRelease
+  ;;
+esac
 
 echo "Building apk from source..."
 
-docker images -a | grep "covidcertificate-builder" | awk '{print $3}' | xargs docker rmi
+# Clean up any existing images
+docker images -a | grep "covidcertificate-builder" | awk '{print $3}' | xargs -r docker rmi
+
+# Freshly build the container image
 docker build -t covidcertificate-builder .
+
+# Prepare the build command (for readability)
 currentPath=`pwd`
-docker run --rm -v $currentPath:/home/covidcertificate/external -w /home/covidcertificate covidcertificate-builder /bin/bash -c "git clone https://github.com/admin-ch/CovidCertificate-App-Android.git; cd CovidCertificate-App-Android; cp /home/covidcertificate/external/$appName/$keystoreFile $appName/$keystoreFile; git checkout $branch; gradle $appName:assembleProdRelease -PkeystorePassword='$keystorePassword' -PkeyAlias=$keyAlias -PkeyAliasPassword='$keyAliasPassword' -PkeystoreFile=$keystoreFile -PbuildTimestamp=$buildTimestamp; cp $appName/build/outputs/apk/prod/release/$appName-prod-release.apk /home/covidcertificate/external/$appName-built.apk"
+buildCommand=$(cat <<EOF
+git clone https://github.com/admin-ch/CovidCertificate-App-Android.git;
+cd CovidCertificate-App-Android;
+git checkout $tree;
+gradle $gradletask -PkeystorePassword=$keystorePassword -PkeyAlias=$keyAlias -PkeyAliasPassword=$keyAliasPassword -PkeystoreFile=/home/covidcertificate/external/$keystoreFile -PbuildTimestamp=$buildTimestamp -Pbranch=buildBranch;
+cp $appName/build/outputs/apk/prod/release/$appName-prod-release.apk /home/covidcertificate/external/$appName-built.apk
+EOF
+)
+buildCommand=$(echo -n "$buildCommand" | tr '\n' ' ' ) # replace newlines by spaces
+
+# Build the app in the container
+docker run --rm -v "$currentPath":/home/covidcertificate/external -w /home/covidcertificate covidcertificate-builder /bin/bash -c -eux "$buildCommand"
 
 echo "Comparing the APK built from source with the reference APK..."
-python apkdiff.py $appName-built.apk $1
+python apkdiff.py $appName-built.apk $referenceApk

--- a/buildAndCompare.sh
+++ b/buildAndCompare.sh
@@ -24,7 +24,7 @@ read -s keyAliasPassword
 echo "Please enter the build timestamp:"
 read buildTimestamp
 
-echo Branch:
+echo "Branch (e.g. release/version-1.0.0)":
 read branch
 
 echo "Building apk from source..."


### PR DESCRIPTION
This PR improves the reproducible build documentation and script, building upon #287.

Features:
- Option to autogenerate a keystore with dummy credentials.
This is useful for users, while we retain the possibility to pass a keystore to be used for signing.
- Option to build the fdroid flavour introduced in #314.
- Simplify the REPRODUCIBLE_BUILDS.md by not having 2 sections for both the wallet and the verifier, and by referencing the buildAndCompare.sh script (rather than providing all commands that the user should run).
- Improve the script to be on shorter lines (especially the `docker run` command)
- Prompt the user to pass a `buildBranch` that overrides whatever is checked out. This is needed for reproducing from git tags. Without this, the gradle variable `branch` (which is set by Ubique's gradle plugin) would be set to HEAD when building from a git tag. This causes it to fail if the APK was build by the CI from e.g. the branch `release/version-2.8.0`.