### PR TITLE
feat: change behavior of "refresh" button

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1290,7 +1290,7 @@ Code: {ERROR_CODE}"</string>
     <string name="covid_certificate_sero_positiv_test_befund_value">"Sufficient"</string>
 
     <!-- Validation button dialog -->
-    <string name="validate_action_title">This is not how you should validate a COVID Certificate!</string>
+    <string name="validate_action_title">Not a validation method!</string>
     <string name="validate_action_explanation"> Check the certificate only with the COVID Certificate Check app.</string>
     <string name="validate_action_fineprint_text">This is the only way of guaranteeing that the certificate presented and the information it contains are genuine and have not been manipulated.
         The look of the app for certificate holders (the COVID Certificate app) could have been simulated. For this reason, manual scrolling, “check on sight” and the use of the “refresh” button are not permitted in the app for certificate holders.

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1288,4 +1288,13 @@ Code: {ERROR_CODE}"</string>
     <string name="wallet_only_valid_in_switzerland">"Only valid within Switzerland and in combination with an identity document"</string>
     <string name="covid_certificate_sero_positiv_test_befund_label">"Finding"</string>
     <string name="covid_certificate_sero_positiv_test_befund_value">"Sufficient"</string>
+
+    <!-- Validation button dialog -->
+    <string name="validate_action_title">This is not how you should validate a COVID Certificate!</string>
+    <string name="validate_action_explanation"> Check the certificate only with the COVID Certificate Check app.</string>
+    <string name="validate_action_fineprint_text">This is the only way of guaranteeing that the certificate presented and the information it contains are genuine and have not been manipulated.
+        The look of the app for certificate holders (the COVID Certificate app) could have been simulated. For this reason, manual scrolling, “check on sight” and the use of the “refresh” button are not permitted in the app for certificate holders.
+        The “refresh” button in the app for certificate holders is only there to enable the holder to see whether the certificate is still valid.</string>
+    <string name="validate_action_ok_button">Understood</string>
+    <string name="validate_action_dismiss_button">Dismiss</string>
 </resources>

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
@@ -146,10 +146,10 @@ class CertificateDetailFragment : Fragment() {
 
 		binding.certificateDetailButtonReverify.setOnClickListener {
 			// Show popup explaining purpose of verification
-			val view = LinearLayout(context)
+			val v = LinearLayout(context)
 			val inflater = LayoutInflater.from(context).inflate(
 				R.layout.dialog_fragment_certificate_scanning_info,
-				view,
+				v,
 			)
 
 			val dialogTitle = inflater.findViewById<TextView>(R.id.scanning_dialog_title)
@@ -165,7 +165,7 @@ class CertificateDetailFragment : Fragment() {
 			val dialogDismissButton = inflater.findViewById<Button>(R.id.scanning_dialog_dismiss_button)
 			dialogDismissButton.text = getString(R.string.validate_action_dismiss_button)
 
-			val dialog = AlertDialog.Builder(view.context, R.style.CovidCertificate_AlertDialogStyle)
+			val dialog = AlertDialog.Builder(v.context, R.style.CovidCertificate_AlertDialogStyle)
 				.setIcon(R.drawable.ic_error_grey)
 				.setCancelable(true)
 				.setView(inflater)
@@ -338,6 +338,12 @@ class CertificateDetailFragment : Fragment() {
 			info = SpannableString(context.getString(R.string.verifier_verify_success_info))
 			iconId = R.drawable.ic_info_blue
 			showRedBorder = false
+		}
+		val forceValidationInfo = context.getString(R.string.wallet_certificate_verify_success).makeBold()
+		if (isForceValidate) {
+			resetStatus(R.color.blueish, info, showRedBorder)
+		} else {
+			showStatusInfoAndDescription(null, info, iconId, showRedBorder)
 		}
 		showStatusInfoAndDescription(null, info, iconId, showRedBorder)
 	}
@@ -595,6 +601,39 @@ class CertificateDetailFragment : Fragment() {
 		binding.certificateDetailInfo.text = info
 		binding.certificateDetailStatusIcon.setImageResource(iconId)
 		binding.certificateDetailInfoRedBorder.visibility = if (showRedBorder) View.VISIBLE else View.GONE
+	}
+
+	/*
+		Resets the view after a validation, without showing any positive / negative action
+	 */
+	private fun resetStatus(
+		@ColorRes infoBubbleColorId: Int,
+		info: SpannableString?,
+		showRedBorder: Boolean = false
+	) {
+		hideDelayedJob?.cancel()
+		hideDelayedJob = viewLifecycleOwner.lifecycleScope.launch {
+			if (!isActive || !isVisible) return@launch
+			val context = binding.root.context
+
+			binding.certificateDetailQrCodeStatusGroup.hideAnimated()
+			binding.certificateDetailQrCodeColor.animateBackgroundTintColor(
+				ContextCompat.getColor(context, android.R.color.transparent)
+			)
+
+			binding.certificateDetailInfo.text = info
+			binding.certificateDetailInfoDescriptionGroup.animateBackgroundTintColor(
+				ContextCompat.getColor(context, infoBubbleColorId)
+			)
+			binding.certificateDetailInfoRedBorder.visibility = if (showRedBorder) View.VISIBLE else View.GONE
+
+			binding.certificateDetailInfoVerificationStatus.hideAnimated()
+			binding.certificateDetailInfoValidityGroup.animateBackgroundTintColor(
+				ContextCompat.getColor(context, infoBubbleColorId)
+			)
+			binding.certificateDetailButtonReverify.showAnimated()
+			isForceValidate = false
+		}
 	}
 
 	/**

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
@@ -17,7 +17,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.annotation.ColorRes
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
@@ -27,6 +31,7 @@ import androidx.fragment.app.viewModels
 import ch.admin.bag.covidcertificate.common.extensions.overrideScreenBrightness
 import ch.admin.bag.covidcertificate.common.util.makeBold
 import ch.admin.bag.covidcertificate.common.views.animateBackgroundTintColor
+import ch.admin.bag.covidcertificate.common.views.hideAnimated
 import ch.admin.bag.covidcertificate.sdk.android.extensions.DEFAULT_DISPLAY_DATE_FORMATTER
 import ch.admin.bag.covidcertificate.sdk.android.extensions.prettyPrintIsoDateTime
 import ch.admin.bag.covidcertificate.sdk.core.extensions.fromBase64
@@ -94,6 +99,42 @@ class CertificateLightDetailFragment : Fragment(R.layout.fragment_certificate_li
 		setupStatusInfo()
 
 		binding.certificateLightDetailDeactivateButton.setOnClickListener { deleteCertificateLightAndShowOriginal() }
+
+		binding.certificateDetailButtonReverify.setOnClickListener {
+			// Show popup explaining purpose of verification
+			val v = LinearLayout(context)
+			val inflater = LayoutInflater.from(context).inflate(
+				R.layout.dialog_fragment_certificate_scanning_info,
+				v,
+			)
+
+			val dialogTitle = inflater.findViewById<TextView>(R.id.scanning_dialog_title)
+			dialogTitle.text = getString(R.string.validate_action_title)
+			val dialogText = inflater.findViewById<TextView>(R.id.scanning_dialog_text)
+			dialogText.text = getString(R.string.validate_action_explanation)
+
+			val dialogFineprint = inflater.findViewById<TextView>(R.id.scanning_dialog_fineprint)
+			dialogFineprint.text = getString(R.string.validate_action_fineprint_text)
+
+			val dialogOkButton = inflater.findViewById<Button>(R.id.scanning_dialog_understood_button)
+			dialogOkButton.text = getString(R.string.validate_action_ok_button)
+			val dialogDismissButton = inflater.findViewById<Button>(R.id.scanning_dialog_dismiss_button)
+			dialogDismissButton.text = getString(R.string.validate_action_dismiss_button)
+
+			val dialog = AlertDialog.Builder(v.context, R.style.CovidCertificate_AlertDialogStyle)
+				.setIcon(R.drawable.ic_error_grey)
+				.setCancelable(true)
+				.setView(inflater)
+				.create()
+
+			dialogOkButton.setOnClickListener {
+				dialog.dismiss()
+			}
+			dialogDismissButton.setOnClickListener {
+				dialog.dismiss()
+			}
+			dialog.show()
+		}
 	}
 
 	override fun onResume() {

--- a/wallet/src/main/res/layout/dialog_fragment_certificate_scanning_info.xml
+++ b/wallet/src/main/res/layout/dialog_fragment_certificate_scanning_info.xml
@@ -25,13 +25,21 @@
 		android:paddingTop="@dimen/spacing_very_large"
 		android:paddingBottom="@dimen/spacing_medium_large">
 
+		<ImageView
+			android:layout_width="40dp"
+			android:layout_height="40dp"
+			android:background="@drawable/ic_error"
+			android:layout_marginBottom="10dp"
+		/>
+
+
 		<TextView
 			android:id="@+id/scanning_dialog_title"
 			style="@style/CovidCertificate.Text.Bold.Title"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:gravity="center"
-			tools:text="This is not how you should validate a COVID Certificate!" />
+			tools:text="Not a validation method" />
 
 		<TextView
 			android:id="@+id/scanning_dialog_text"

--- a/wallet/src/main/res/layout/dialog_fragment_certificate_scanning_info.xml
+++ b/wallet/src/main/res/layout/dialog_fragment_certificate_scanning_info.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  ~
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="wrap_content"
+	android:layout_height="wrap_content"
+	android:overScrollMode="never">
+
+	<LinearLayout
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:gravity="center_horizontal"
+		android:orientation="vertical"
+		android:padding="30dp"
+		android:paddingHorizontal="@dimen/spacing_very_large"
+		android:paddingTop="@dimen/spacing_very_large"
+		android:paddingBottom="@dimen/spacing_medium_large">
+
+		<TextView
+			android:id="@+id/scanning_dialog_title"
+			style="@style/CovidCertificate.Text.Bold.Title"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:gravity="center"
+			tools:text="This is not how you should validate a COVID Certificate!" />
+
+		<TextView
+			android:id="@+id/scanning_dialog_text"
+			style="@style/CovidCertificate.Text"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="@dimen/spacing_very_large"
+			android:breakStrategy="high_quality"
+			android:gravity="center"
+			android:hyphenationFrequency="normal"
+			tools:text=" Check the certificate only with the COVID Certificate Check app." />
+
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
+			android:layout_marginTop="@dimen/spacing_very_large"
+		>
+			<TextView
+				android:id="@+id/scanning_dialog_fineprint"
+				style="@style/Scanning.Text"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:breakStrategy="simple"
+				android:gravity="left"
+				android:hyphenationFrequency="normal"
+				tools:text="Always use the COVID Certificate Check app to check the QR codes. This is the only way of guaranteeing that the certificate presented and the information it contains are genuine.\n\nThe look of the app for certificate holders (the COVID Certificate app) could have been simulated. For this reason, manual scrolling, “check on sight” and the use of the “refresh” button are not permitted in the app for certificate holders.\n\nThe “refresh” button in the app for certificate holders is only there to enable the holder to see whether the certificate is still valid." />
+
+		</LinearLayout>
+
+		<Button
+			android:id="@+id/scanning_dialog_understood_button"
+			style="@style/CovidCertificate.Button"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="@dimen/spacing_very_large"
+			android:layout_marginBottom="@dimen/spacing_medium_large"
+			tools:text="Understood" />
+
+		<Button
+			android:id="@+id/scanning_dialog_dismiss_button"
+			style="@style/CovidCertificate.Button.Borderless"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			tools:text="Dismiss" />
+
+	</LinearLayout>
+</ScrollView>

--- a/wallet/src/main/res/layout/fragment_certificate_light_detail.xml
+++ b/wallet/src/main/res/layout/fragment_certificate_light_detail.xml
@@ -32,265 +32,283 @@
 			app:titleTextAppearance="@style/CovidCertificate.ToolbarTitle"
 			app:titleTextColor="@color/grey" />
 
-		<ScrollView
+		<FrameLayout
 			android:layout_width="match_parent"
 			android:layout_height="match_parent">
 
-			<LinearLayout
+			<androidx.core.widget.NestedScrollView
+				android:id="@+id/scrollview"
 				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:orientation="vertical">
-
-				<ImageView
-					android:id="@+id/certificate_light_detail_qr_code"
-					android:layout_width="match_parent"
-					android:layout_height="wrap_content"
-					android:layout_gravity="center"
-					android:layout_marginHorizontal="@dimen/spacing_very_very_large"
-					android:layout_marginTop="@dimen/spacing_medium_large"
-					android:adjustViewBounds="true"
-					tools:src="@drawable/ic_qrcode_add" />
-
-				<TextView
-					android:id="@+id/certificate_light_detail_validity"
-					style="@style/CovidCertificate.Text.Bold.Emphasized.Blue"
-					android:layout_width="wrap_content"
-					android:layout_height="wrap_content"
-					android:layout_gravity="center"
-					android:layout_marginTop="@dimen/spacing_large"
-					android:background="@drawable/bg_certificate_bubble"
-					android:fontFeatureSettings="tnum"
-					android:paddingHorizontal="@dimen/spacing_small"
-					android:paddingVertical="3dp"
-					tools:text="47:59:59" />
-
-				<TextView
-					android:id="@+id/certificate_light_detail_name"
-					style="@style/CovidCertificate.Text.Bold.Title"
-					android:layout_width="match_parent"
-					android:layout_height="wrap_content"
-					android:layout_marginHorizontal="@dimen/spacing_very_very_large"
-					android:layout_marginTop="@dimen/spacing_huge"
-					android:gravity="center_horizontal"
-					tools:text="Muster Marta" />
-
-				<TextView
-					android:id="@+id/certificate_light_detail_birthdate"
-					style="@style/CovidCertificate.Text"
-					android:layout_width="wrap_content"
-					android:layout_height="wrap_content"
-					android:layout_gravity="center_horizontal"
-					android:layout_marginTop="@dimen/spacing_very_small"
-					tools:text="21.11.1966" />
-
-				<androidx.constraintlayout.widget.ConstraintLayout
-					android:layout_width="match_parent"
-					android:layout_height="wrap_content"
-					android:layout_marginHorizontal="@dimen/spacing_very_very_large"
-					android:clipChildren="false"
-					android:clipToPadding="false"
-					android:paddingTop="@dimen/spacing_very_large">
-
-					<TextView
-						android:id="@+id/certificate_light_detail_verification_status"
-						style="@style/CovidCertificate.Text"
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:background="@drawable/bg_certificate_bubble"
-						android:gravity="center"
-						android:minLines="2"
-						android:padding="@dimen/spacing_medium_large"
-						app:backgroundTint="@color/blueish"
-						app:layout_constraintBottom_toBottomOf="parent"
-						app:layout_constraintTop_toTopOf="parent"
-						tools:text="@string/verifier_verify_success_certificate_light_info" />
-
-					<ImageView
-						android:id="@+id/certificate_detail_info_red_border"
-						android:layout_width="0dp"
-						android:layout_height="0dp"
-						app:layout_constraintStart_toStartOf="@id/certificate_light_detail_verification_status"
-						app:layout_constraintEnd_toEndOf="@id/certificate_light_detail_verification_status"
-						app:layout_constraintTop_toTopOf="@id/certificate_light_detail_verification_status"
-						app:layout_constraintBottom_toBottomOf="@id/certificate_light_detail_verification_status"
-						android:src="@drawable/bg_certificate_bubble_bundesrot"/>
-
-					<FrameLayout
-						android:layout_width="wrap_content"
-						android:layout_height="wrap_content"
-						android:background="@drawable/circle_white"
-						android:padding="@dimen/info_buble_icon_padding"
-						app:layout_constraintBottom_toTopOf="@id/certificate_light_detail_verification_status"
-						app:layout_constraintEnd_toEndOf="parent"
-						app:layout_constraintStart_toStartOf="parent"
-						app:layout_constraintTop_toTopOf="@id/certificate_light_detail_verification_status">
-
-						<ImageView
-							android:id="@+id/certificate_light_detail_status_icon"
-							android:layout_width="26dp"
-							android:layout_height="26dp"
-							android:layout_gravity="center"
-							android:scaleType="centerInside"
-							app:srcCompat="@drawable/ic_info_blue" />
-
-						<ProgressBar
-							android:id="@+id/certificate_light_detail_status_loading"
-							android:layout_width="26dp"
-							android:layout_height="26dp"
-							android:visibility="gone" />
-					</FrameLayout>
-
-				</androidx.constraintlayout.widget.ConstraintLayout>
+				android:layout_height="match_parent">
 
 				<LinearLayout
 					android:layout_width="match_parent"
 					android:layout_height="wrap_content"
-					android:layout_marginHorizontal="@dimen/spacing_medium_large"
-					android:layout_marginTop="@dimen/spacing_huge"
-					android:layout_marginBottom="@dimen/spacing_large"
-					android:background="@drawable/bg_certificate_bubble"
 					android:orientation="vertical">
 
+					<ImageView
+						android:id="@+id/certificate_light_detail_qr_code"
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:layout_gravity="center"
+						android:layout_marginHorizontal="@dimen/spacing_very_very_large"
+						android:layout_marginTop="@dimen/spacing_medium_large"
+						android:adjustViewBounds="true"
+						tools:src="@drawable/ic_qrcode_add" />
+
 					<TextView
-						style="@style/CovidCertificate.Text.Bold.Emphasized"
+						android:id="@+id/certificate_light_detail_validity"
+						style="@style/CovidCertificate.Text.Bold.Emphasized.Blue"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:layout_gravity="center"
+						android:layout_marginTop="@dimen/spacing_large"
+						android:background="@drawable/bg_certificate_bubble"
+						android:fontFeatureSettings="tnum"
+						android:paddingHorizontal="@dimen/spacing_small"
+						android:paddingVertical="3dp"
+						tools:text="47:59:59" />
+
+					<TextView
+						android:id="@+id/certificate_light_detail_name"
+						style="@style/CovidCertificate.Text.Bold.Title"
 						android:layout_width="match_parent"
 						android:layout_height="wrap_content"
-						android:layout_marginHorizontal="@dimen/spacing_medium_large"
-						android:layout_marginTop="@dimen/spacing_large"
-						android:gravity="center"
-						android:text="@string/wallet_certificate_light_detail_summary_title" />
+						android:layout_marginHorizontal="@dimen/spacing_very_very_large"
+						android:layout_marginTop="@dimen/spacing_huge"
+						android:gravity="center_horizontal"
+						tools:text="Muster Marta" />
 
-					<LinearLayout
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:layout_marginHorizontal="@dimen/spacing_medium_large"
-						android:layout_marginTop="@dimen/spacing_large"
-						android:orientation="horizontal"
-						tools:ignore="UseCompoundDrawables">
-
-						<ImageView
-							android:layout_width="@dimen/icon_size_small"
-							android:layout_height="@dimen/icon_size_small"
-							app:srcCompat="@drawable/ic_bundwappen_big" />
-
-						<TextView
-							style="@style/CovidCertificate.Text"
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:layout_marginStart="@dimen/spacing_large"
-							android:breakStrategy="high_quality"
-							android:hyphenationFrequency="full"
-							android:text="@string/wallet_certificate_light_detail_summary_1" />
-					</LinearLayout>
-
-					<LinearLayout
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:layout_marginHorizontal="@dimen/spacing_medium_large"
-						android:layout_marginTop="@dimen/spacing_large"
-						android:orientation="horizontal"
-						tools:ignore="UseCompoundDrawables">
-
-						<ImageView
-							android:layout_width="@dimen/icon_size_small"
-							android:layout_height="@dimen/icon_size_small"
-							app:srcCompat="@drawable/ic_privacy"
-							app:tint="@color/blue" />
-
-						<TextView
-							style="@style/CovidCertificate.Text"
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:layout_marginStart="@dimen/spacing_large"
-							android:breakStrategy="high_quality"
-							android:hyphenationFrequency="full"
-							android:text="@string/wallet_certificate_light_detail_summary_2" />
-					</LinearLayout>
-
-					<LinearLayout
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:layout_marginHorizontal="@dimen/spacing_medium_large"
-						android:layout_marginTop="@dimen/spacing_large"
-						android:orientation="horizontal"
-						tools:ignore="UseCompoundDrawables">
-
-						<ImageView
-							android:layout_width="@dimen/icon_size_small"
-							android:layout_height="@dimen/icon_size_small"
-							app:srcCompat="@drawable/ic_timelapse"
-							app:tint="@color/blue" />
-
-						<TextView
-							style="@style/CovidCertificate.Text"
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:layout_marginStart="@dimen/spacing_large"
-							android:breakStrategy="high_quality"
-							android:hyphenationFrequency="full"
-							android:text="@string/wallet_certificate_light_detail_summary_3" />
-					</LinearLayout>
-
-					<LinearLayout
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:layout_marginHorizontal="@dimen/spacing_medium_large"
-						android:layout_marginTop="@dimen/spacing_large"
-						android:orientation="horizontal"
-						tools:ignore="UseCompoundDrawables">
-
-						<ImageView
-							android:layout_width="@dimen/icon_size_small"
-							android:layout_height="@dimen/icon_size_small"
-							app:srcCompat="@drawable/ic_cloud"
-							app:tint="@color/blue" />
-
-						<TextView
-							style="@style/CovidCertificate.Text"
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:layout_marginStart="@dimen/spacing_large"
-							android:breakStrategy="high_quality"
-							android:hyphenationFrequency="full"
-							android:text="@string/wallet_certificate_light_detail_summary_4" />
-					</LinearLayout>
-
-					<LinearLayout
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:layout_marginHorizontal="@dimen/spacing_medium_large"
-						android:layout_marginTop="@dimen/spacing_large"
-						android:orientation="horizontal"
-						tools:ignore="UseCompoundDrawables">
-
-						<ImageView
-							android:layout_width="@dimen/icon_size_small"
-							android:layout_height="@dimen/icon_size_small"
-							app:srcCompat="@drawable/ic_exchange"
-							app:tint="@color/blue" />
-
-						<TextView
-							style="@style/CovidCertificate.Text"
-							android:layout_width="match_parent"
-							android:layout_height="wrap_content"
-							android:layout_marginStart="@dimen/spacing_large"
-							android:breakStrategy="high_quality"
-							android:hyphenationFrequency="full"
-							android:text="@string/wallet_certificate_light_detail_summary_5" />
-					</LinearLayout>
-
-					<Button
-						android:id="@+id/certificate_light_detail_deactivate_button"
-						style="@style/CovidCertificate.Button.Red"
+					<TextView
+						android:id="@+id/certificate_light_detail_birthdate"
+						style="@style/CovidCertificate.Text"
 						android:layout_width="wrap_content"
 						android:layout_height="wrap_content"
 						android:layout_gravity="center_horizontal"
-						android:layout_marginTop="@dimen/spacing_very_large"
-						android:layout_marginBottom="@dimen/spacing_huge"
-						android:text="@string/wallet_certificate_light_detail_deactivate_button" />
-				</LinearLayout>
+						android:layout_marginTop="@dimen/spacing_very_small"
+						tools:text="21.11.1966" />
 
-			</LinearLayout>
-		</ScrollView>
+					<androidx.constraintlayout.widget.ConstraintLayout
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:layout_marginHorizontal="@dimen/spacing_very_very_large"
+						android:clipChildren="false"
+						android:clipToPadding="false"
+						android:paddingTop="@dimen/spacing_very_large">
+
+						<TextView
+							android:id="@+id/certificate_light_detail_verification_status"
+							style="@style/CovidCertificate.Text"
+							android:layout_width="match_parent"
+							android:layout_height="wrap_content"
+							android:background="@drawable/bg_certificate_bubble"
+							android:gravity="center"
+							android:minLines="2"
+							android:padding="@dimen/spacing_medium_large"
+							app:backgroundTint="@color/blueish"
+							app:layout_constraintBottom_toBottomOf="parent"
+							app:layout_constraintTop_toTopOf="parent"
+							tools:text="@string/verifier_verify_success_certificate_light_info" />
+
+						<ImageView
+							android:id="@+id/certificate_detail_info_red_border"
+							android:layout_width="0dp"
+							android:layout_height="0dp"
+							android:src="@drawable/bg_certificate_bubble_bundesrot"
+							app:layout_constraintBottom_toBottomOf="@id/certificate_light_detail_verification_status"
+							app:layout_constraintEnd_toEndOf="@id/certificate_light_detail_verification_status"
+							app:layout_constraintStart_toStartOf="@id/certificate_light_detail_verification_status"
+							app:layout_constraintTop_toTopOf="@id/certificate_light_detail_verification_status" />
+
+						<FrameLayout
+							android:layout_width="wrap_content"
+							android:layout_height="wrap_content"
+							android:background="@drawable/circle_white"
+							android:padding="@dimen/info_buble_icon_padding"
+							app:layout_constraintBottom_toTopOf="@id/certificate_light_detail_verification_status"
+							app:layout_constraintEnd_toEndOf="parent"
+							app:layout_constraintStart_toStartOf="parent"
+							app:layout_constraintTop_toTopOf="@id/certificate_light_detail_verification_status">
+
+							<ImageView
+								android:id="@+id/certificate_light_detail_status_icon"
+								android:layout_width="26dp"
+								android:layout_height="26dp"
+								android:layout_gravity="center"
+								android:scaleType="centerInside"
+								app:srcCompat="@drawable/ic_info_blue" />
+
+							<ProgressBar
+								android:id="@+id/certificate_light_detail_status_loading"
+								android:layout_width="26dp"
+								android:layout_height="26dp"
+								android:visibility="gone" />
+						</FrameLayout>
+
+					</androidx.constraintlayout.widget.ConstraintLayout>
+
+					<LinearLayout
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:layout_marginHorizontal="@dimen/spacing_medium_large"
+						android:layout_marginTop="@dimen/spacing_huge"
+						android:layout_marginBottom="@dimen/spacing_large"
+						android:background="@drawable/bg_certificate_bubble"
+						android:orientation="vertical">
+
+						<TextView
+							style="@style/CovidCertificate.Text.Bold.Emphasized"
+							android:layout_width="match_parent"
+							android:layout_height="wrap_content"
+							android:layout_marginHorizontal="@dimen/spacing_medium_large"
+							android:layout_marginTop="@dimen/spacing_large"
+							android:gravity="center"
+							android:text="@string/wallet_certificate_light_detail_summary_title" />
+
+						<LinearLayout
+							android:layout_width="match_parent"
+							android:layout_height="wrap_content"
+							android:layout_marginHorizontal="@dimen/spacing_medium_large"
+							android:layout_marginTop="@dimen/spacing_large"
+							android:orientation="horizontal"
+							tools:ignore="UseCompoundDrawables">
+
+							<ImageView
+								android:layout_width="@dimen/icon_size_small"
+								android:layout_height="@dimen/icon_size_small"
+								app:srcCompat="@drawable/ic_bundwappen_big" />
+
+							<TextView
+								style="@style/CovidCertificate.Text"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginStart="@dimen/spacing_large"
+								android:breakStrategy="high_quality"
+								android:hyphenationFrequency="full"
+								android:text="@string/wallet_certificate_light_detail_summary_1" />
+						</LinearLayout>
+
+						<LinearLayout
+							android:layout_width="match_parent"
+							android:layout_height="wrap_content"
+							android:layout_marginHorizontal="@dimen/spacing_medium_large"
+							android:layout_marginTop="@dimen/spacing_large"
+							android:orientation="horizontal"
+							tools:ignore="UseCompoundDrawables">
+
+							<ImageView
+								android:layout_width="@dimen/icon_size_small"
+								android:layout_height="@dimen/icon_size_small"
+								app:srcCompat="@drawable/ic_privacy"
+								app:tint="@color/blue" />
+
+							<TextView
+								style="@style/CovidCertificate.Text"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginStart="@dimen/spacing_large"
+								android:breakStrategy="high_quality"
+								android:hyphenationFrequency="full"
+								android:text="@string/wallet_certificate_light_detail_summary_2" />
+						</LinearLayout>
+
+						<LinearLayout
+							android:layout_width="match_parent"
+							android:layout_height="wrap_content"
+							android:layout_marginHorizontal="@dimen/spacing_medium_large"
+							android:layout_marginTop="@dimen/spacing_large"
+							android:orientation="horizontal"
+							tools:ignore="UseCompoundDrawables">
+
+							<ImageView
+								android:layout_width="@dimen/icon_size_small"
+								android:layout_height="@dimen/icon_size_small"
+								app:srcCompat="@drawable/ic_timelapse"
+								app:tint="@color/blue" />
+
+							<TextView
+								style="@style/CovidCertificate.Text"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginStart="@dimen/spacing_large"
+								android:breakStrategy="high_quality"
+								android:hyphenationFrequency="full"
+								android:text="@string/wallet_certificate_light_detail_summary_3" />
+						</LinearLayout>
+
+						<LinearLayout
+							android:layout_width="match_parent"
+							android:layout_height="wrap_content"
+							android:layout_marginHorizontal="@dimen/spacing_medium_large"
+							android:layout_marginTop="@dimen/spacing_large"
+							android:orientation="horizontal"
+							tools:ignore="UseCompoundDrawables">
+
+							<ImageView
+								android:layout_width="@dimen/icon_size_small"
+								android:layout_height="@dimen/icon_size_small"
+								app:srcCompat="@drawable/ic_cloud"
+								app:tint="@color/blue" />
+
+							<TextView
+								style="@style/CovidCertificate.Text"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginStart="@dimen/spacing_large"
+								android:breakStrategy="high_quality"
+								android:hyphenationFrequency="full"
+								android:text="@string/wallet_certificate_light_detail_summary_4" />
+						</LinearLayout>
+
+						<LinearLayout
+							android:layout_width="match_parent"
+							android:layout_height="wrap_content"
+							android:layout_marginHorizontal="@dimen/spacing_medium_large"
+							android:layout_marginTop="@dimen/spacing_large"
+							android:orientation="horizontal"
+							tools:ignore="UseCompoundDrawables">
+
+							<ImageView
+								android:layout_width="@dimen/icon_size_small"
+								android:layout_height="@dimen/icon_size_small"
+								app:srcCompat="@drawable/ic_exchange"
+								app:tint="@color/blue" />
+
+							<TextView
+								style="@style/CovidCertificate.Text"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:layout_marginStart="@dimen/spacing_large"
+								android:breakStrategy="high_quality"
+								android:hyphenationFrequency="full"
+								android:text="@string/wallet_certificate_light_detail_summary_5" />
+						</LinearLayout>
+
+						<Button
+							android:id="@+id/certificate_light_detail_deactivate_button"
+							style="@style/CovidCertificate.Button.Red"
+							android:layout_width="wrap_content"
+							android:layout_height="wrap_content"
+							android:layout_gravity="center_horizontal"
+							android:layout_marginTop="@dimen/spacing_very_large"
+							android:layout_marginBottom="@dimen/spacing_huge"
+							android:text="@string/wallet_certificate_light_detail_deactivate_button" />
+					</LinearLayout>
+
+				</LinearLayout>
+			</androidx.core.widget.NestedScrollView>
+
+			<ImageButton
+				android:id="@+id/certificate_detail_button_reverify"
+				style="@style/CovidCertificate.FloatingImageButton"
+				android:layout_width="@dimen/floating_button_height"
+				android:layout_height="@dimen/floating_button_height"
+				android:layout_gravity="bottom|end"
+				android:layout_marginEnd="@dimen/spacing_very_large"
+				android:layout_marginBottom="@dimen/spacing_very_large"
+				android:elevation="@dimen/floating_button_elevation"
+				app:srcCompat="@drawable/ic_load" />
+		</FrameLayout>
+
 	</LinearLayout>
 </ch.admin.bag.covidcertificate.common.views.WindowInsetsLayout>

--- a/wallet/src/main/res/values/styles.xml
+++ b/wallet/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Scanning.Text" parent="TextAppearance.AppCompat">
+        <item name="android:textSize">@dimen/text_size_small</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:fontFamily">@font/inter</item>
+        <item name="fontFamily">@font/inter</item>
+        <item name="lineHeight">@dimen/text_line_height_bubble</item>
+    </style>
+</resources>


### PR DESCRIPTION
This PR could solve #295.
---

The "refresh" button has been wrongly interpreted both by the
certificate holders (users) and the people checking the certificates
(scanners).

Nowadays when visiting a venue that requires a COVID Certificate
verification the certificate will not be scanned with the official
COVID Certificate Check app, but rather the scanner will press the
"refresh" button on the user phone.

This obviously defeats the purpose of having a cryptographically secure
QR code signed by a trusted party.

This behavior has been adopted due to a mistake in the UI / UX design,
where clicking the "refresh" button makes the QR code and the
information bubbles go green for a couple of seconds, saying
"verification successful".

A misinterpretation of the feature has thus caused an extremely
wrong and dangerous pattern when scanning the certificates.

This commit partially fixes the issue by adding a notice
_every time_ that button is pressed, and by hiding the green
verification icons / colors. An invalid certificate will anyways
result in a red background as usual.

TODO: Add translations


## Current App (mocked valid certificate)

https://user-images.githubusercontent.com/4939519/142692818-317ec45b-8823-4879-a1a5-f02729577c9c.mp4

## This PR

https://user-images.githubusercontent.com/4939519/142701018-5c9fd88b-eb03-4913-b48d-25fe4b73d10e.mp4

### Dialog Screenshot

<p align="center">
<img src="https://user-images.githubusercontent.com/4939519/142700254-538fd3c2-d318-4547-a1a3-68be92af4650.jpg" width="400"/>
</p>
