### PR TITLE
feat: make the light certificate B/W

### DIFF
--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
@@ -38,10 +38,7 @@ import ch.admin.bag.covidcertificate.wallet.R
 import ch.admin.bag.covidcertificate.wallet.databinding.FragmentCertificateLightDetailBinding
 import ch.admin.bag.covidcertificate.wallet.detail.CertificateDetailFragment
 import ch.admin.bag.covidcertificate.wallet.homescreen.pager.StatefulWalletItem
-import ch.admin.bag.covidcertificate.wallet.util.getNameDobColor
-import ch.admin.bag.covidcertificate.wallet.util.getQrAlpha
-import ch.admin.bag.covidcertificate.wallet.util.getValidationStatusString
-import ch.admin.bag.covidcertificate.wallet.util.isOfflineMode
+import ch.admin.bag.covidcertificate.wallet.util.*
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -111,7 +108,7 @@ class CertificateLightDetailFragment : Fragment(R.layout.fragment_certificate_li
 	private fun displayQrCode() {
 		val decoded = qrCodeImage.fromBase64()
 		val qrCodeBitmap = BitmapFactory.decodeByteArray(decoded, 0, decoded.size)
-		val qrCodeDrawable = BitmapDrawable(resources, qrCodeBitmap)
+		val qrCodeDrawable = BitmapDrawable(resources, QrCode.convertBitmapToBw(qrCodeBitmap))
 		binding.certificateLightDetailQrCode.setImageDrawable(qrCodeDrawable)
 	}
 

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightPagerFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightPagerFragment.kt
@@ -34,10 +34,7 @@ import ch.admin.bag.covidcertificate.wallet.CertificatesViewModel
 import ch.admin.bag.covidcertificate.wallet.R
 import ch.admin.bag.covidcertificate.wallet.databinding.FragmentCertificateLightPagerBinding
 import ch.admin.bag.covidcertificate.wallet.homescreen.pager.StatefulWalletItem
-import ch.admin.bag.covidcertificate.wallet.util.getNameDobColor
-import ch.admin.bag.covidcertificate.wallet.util.getQrAlpha
-import ch.admin.bag.covidcertificate.wallet.util.getValidationStatusString
-import ch.admin.bag.covidcertificate.wallet.util.isOfflineMode
+import ch.admin.bag.covidcertificate.wallet.util.*
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -108,7 +105,7 @@ class CertificateLightPagerFragment : Fragment(R.layout.fragment_certificate_lig
 	private fun displayQrCode() {
 		val decoded = qrCodeImage.fromBase64()
 		val qrCodeBitmap = BitmapFactory.decodeByteArray(decoded, 0, decoded.size)
-		val qrCodeDrawable = BitmapDrawable(resources, qrCodeBitmap)
+		val qrCodeDrawable = BitmapDrawable(resources, QrCode.convertBitmapToBw(qrCodeBitmap))
 		binding.certificatePageQrCode.setImageDrawable(qrCodeDrawable)
 	}
 

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/util/QrCode.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/util/QrCode.kt
@@ -13,6 +13,8 @@ package ch.admin.bag.covidcertificate.wallet.util
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Parcel
+import androidx.core.graphics.get
+import androidx.core.graphics.set
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.MultiFormatWriter
@@ -46,6 +48,19 @@ class QrCode private constructor(val data: String, val size: Int) {
 				}
 			}
 			return bitmap
+		}
+
+		fun convertBitmapToBw(input: Bitmap): Bitmap {
+			val mutableBitmap = input.copy(input.config, true)
+			for(x in 0 until mutableBitmap.width){
+				for(y in 0 until mutableBitmap.height) {
+					val p = mutableBitmap[x, y]
+					if(p != Color.WHITE && p != Color.BLACK) {
+						mutableBitmap[x, y] = Color.BLACK
+					}
+				}
+			}
+			return mutableBitmap
 		}
 	}
 


### PR DESCRIPTION
With this PR, the light certificate (which comes from the server already colored with a blueish color) is redrawn in black and white.  
  
This change is to improve contrast, as I found myself multiple time in difficulty while trying to use my Certificate Light at bars where there is a lower amount of light.  
  
With this change, the contrast is increased and thus the certificate gets scanned immediately.  
  
I genuinely lost a good 6 minutes last time at a bar because the contrast of the Certificate Light is too low and the verifier's phone was unable to read the QR code.

### Before

As you can see here, the light-blue color blends with the background. Of course under certain circumnstances this QR code is going to be more difficult to be scanned.

<p align="center">
<img src="https://user-images.githubusercontent.com/4939519/144138512-f00296cc-209d-41e7-8e9d-df39227b3fc7.png" width="400"/>
</p>


### After

Here the contrast ratio is increased (black on white), and thus the certificate can be easily scanned under different light conditions.

<p align="center">
<img src="https://user-images.githubusercontent.com/4939519/144138528-fb76117e-2c94-4d9f-b4d9-f9cb283907c2.png" width="400"/>
</p>
