### PR TITLE
Use 'null-safe' helpers to print the PersonName. Fixes #370.

### DIFF
--- a/verifier/src/main/java/ch/admin/bag/covidcertificate/verifier/verification/VerificationFragment.kt
+++ b/verifier/src/main/java/ch/admin/bag/covidcertificate/verifier/verification/VerificationFragment.kt
@@ -169,18 +169,10 @@ class VerificationFragment : Fragment() {
 		binding.verificationScrollView.smoothScrollTo(0, 0)
 		val personName = certificateHolder.getPersonName()
 
-		if (personName.familyName.isNullOrBlank()) {
-			binding.verificationFamilyName.text = personName.standardizedFamilyName
-		} else {
-			binding.verificationFamilyName.text = personName.familyName
-		}
-		if (personName.givenName.isNullOrBlank()) {
-			binding.verificationGivenName.text = personName.standardizedGivenName
-		} else {
-			binding.verificationGivenName.text = personName.givenName
-		}
+		binding.verificationFamilyName.text = personName.prettyFamilyName()
+		binding.verificationGivenName.text = personName.prettyGivenName()
 		binding.verificationBirthdate.text = certificateHolder.getFormattedDateOfBirth()
-		binding.verificationStandardizedNameLabel.text = "${personName.standardizedFamilyName}<<${personName.standardizedGivenName}"
+		binding.verificationStandardizedNameLabel.text = personName.prettyStandardizedName()
 
 		verificationViewModel.startVerification(
 			certificateHolder,

--- a/wallet/src/dev/java/ch/admin/bag/covidcertificate/wallet/debug/DebugCertificateItem.kt
+++ b/wallet/src/dev/java/ch/admin/bag/covidcertificate/wallet/debug/DebugCertificateItem.kt
@@ -56,9 +56,7 @@ data class DebugCertificateItem(val verifiedCertificate: StatefulWalletItem.Veri
 		}
 
 		// Name
-		val name = certificate?.certificate?.getPersonName()?.let {
-			"${it.familyName} ${it.givenName}"
-		} ?: verifiedCertificate.qrCodeData
+		val name = certificate?.certificate?.getPersonName()?.prettyName() ?: verifiedCertificate.qrCodeData
 		val qrAlpha = state.getQrAlpha()
 		itemView.findViewById<TextView>(R.id.item_certificate_list_name).apply {
 			text = name

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/add/CertificateAddFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/add/CertificateAddFragment.kt
@@ -125,9 +125,7 @@ class CertificateAddFragment : Fragment() {
 		val adapter = CertificateDetailAdapter()
 		recyclerView.adapter = adapter
 
-		val personName = certificateHolder.certificate.getPersonName()
-		val name = "${personName.familyName} ${personName.givenName}"
-		binding.certificateAddName.text = name
+		binding.certificateAddName.text = certificateHolder.certificate.getPersonName().prettyName()
 		binding.certificateAddBirthdate.text = certificateHolder.certificate.getFormattedDateOfBirth()
 
 		val detailItems = CertificateDetailItemListBuilder(

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
@@ -195,9 +195,7 @@ class CertificateDetailFragment : Fragment() {
 		val adapter = CertificateDetailAdapter()
 		recyclerView.adapter = adapter
 
-		val personName = certificateHolder.certificate.getPersonName()
-		val name = "${personName.familyName} ${personName.givenName}"
-		binding.certificateDetailName.text = name
+		binding.certificateDetailName.text = certificateHolder.certificate.getPersonName().prettyName()
 		binding.certificateDetailBirthdate.text = certificateHolder.certificate.getFormattedDateOfBirth()
 
 		binding.certificateDetailInfo.setText(R.string.verifier_verify_success_info)

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/pager/CertificatePagerFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/pager/CertificatePagerFragment.kt
@@ -77,7 +77,7 @@ class CertificatePagerFragment : Fragment() {
 		val qrCodeDrawable = BitmapDrawable(resources, qrCodeBitmap).apply { isFilterBitmap = false }
 		binding.certificatePageQrCode.setImageDrawable(qrCodeDrawable)
 
-		val name = certificateHolder?.certificate?.getPersonName()?.let { "${it.familyName} ${it.givenName}" }
+		val name = certificateHolder?.certificate?.getPersonName()?.prettyName() ?: ""
 		binding.certificatePageName.text = name
 		binding.certificatePageBirthdate.text = certificateHolder?.certificate?.getFormattedDateOfBirth()
 		binding.certificatePageCard.setCutOutCardBackground()

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightDetailFragment.kt
@@ -153,8 +153,7 @@ class CertificateLightDetailFragment : Fragment(R.layout.fragment_certificate_li
 	private fun displayCertificateDetails() {
 		val chLightCert = certificateHolder.certificate as? ChLightCert ?: return
 
-		val name = "${chLightCert.person.familyName} ${chLightCert.person.givenName}"
-		binding.certificateLightDetailName.text = name
+		binding.certificateLightDetailName.text = chLightCert.person.prettyName()
 		val dateOfBirth = chLightCert.dateOfBirth.prettyPrintIsoDateTime(DEFAULT_DISPLAY_DATE_FORMATTER)
 		binding.certificateLightDetailBirthdate.text = dateOfBirth
 	}

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightPagerFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/light/CertificateLightPagerFragment.kt
@@ -113,8 +113,7 @@ class CertificateLightPagerFragment : Fragment(R.layout.fragment_certificate_lig
 	}
 
 	private fun displayCertificateDetails() {
-		val name = certificateHolder.certificate.getPersonName().let { "${it.familyName} ${it.givenName}" }
-		binding.certificatePageName.text = name
+		binding.certificatePageName.text = certificateHolder.certificate.getPersonName().prettyName()
 		binding.certificatePageBirthdate.text = certificateHolder.certificate.getFormattedDateOfBirth()
 	}
 

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/list/WalletDataListItem.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/list/WalletDataListItem.kt
@@ -47,7 +47,7 @@ sealed class WalletDataListItem {
 			val certificate = verifiedCertificate.certificateHolder
 			val certType = certificate?.certType
 
-			val name = certificate?.certificate?.getPersonName()?.let { "${it.familyName} ${it.givenName}" }
+			val name = certificate?.certificate?.getPersonName()?.prettyName() ?: ""
 			val qrAlpha = state.getQrAlpha()
 			binding.itemCertificateListName.text = name
 			binding.itemCertificateListName.alpha = qrAlpha


### PR DESCRIPTION
~*Marked as WIP until https://github.com/admin-ch/CovidCertificate-SDK-Kotlin/pull/60 is propagated up here (this is why the CI build fails). Otherwise ready!*~

Use the helper methods introduced in the SDK [here](https://github.com/admin-ch/CovidCertificate-SDK-Kotlin/pull/60) to print the names. Fixes #370.

What is fixed:
- wallet: did not handle the non-standard names being null, now handled.
- verifier: non-standard names =null were already handled, now standardizedGivenName=null is handled as well.

Tested with some Swiss certificates (nothing breaks) and the topmost certificate from Singapore [here](https://github.com/eu-digital-green-certificates/dgc-testdata/tree/main/SG) (it's actually a fix).

|Before|After|
|---|---|
| <img src=https://user-images.githubusercontent.com/56064810/148381049-bc66050a-c9a7-4dce-8c12-122848cee0b0.jpg width=60%> | <img src=https://user-images.githubusercontent.com/56064810/148381042-151291dc-b089-47c6-b832-8f726bc9ac7a.jpg width=60%> |
| <img src=https://user-images.githubusercontent.com/56064810/148381045-da426dfc-14e5-42a8-8f1a-112ab0ceb26d.jpg width=60%>  | <img src=https://user-images.githubusercontent.com/56064810/148381047-ca7aa1ce-9c15-4a01-99f2-2aaf06d8f9b6.jpg width=60%> |

