### PR TITLE
Cert display: validity until / validity since

### DIFF
--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/config/ConfigModel.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/config/ConfigModel.kt
@@ -47,6 +47,7 @@ data class ConfigModel(
 	val showRatConversionForm: Boolean?,
 	val ratConversionFormUrl: String?,
 	val certRenewalInfo: Map<String, Map<CertificateRenewalType, CertificateRenewalInfoModel>>?,
+	val showValiditySince: Boolean?,
 ) {
 	fun getInfoBox(languageKey: String?): InfoBoxModel? = infoBox?.get(languageKey)
 	fun getQuestionsFaqs(languageKey: String): FaqModel? = questions?.get(languageKey)

--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/config/ConfigModel.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/config/ConfigModel.kt
@@ -47,7 +47,7 @@ data class ConfigModel(
 	val showRatConversionForm: Boolean?,
 	val ratConversionFormUrl: String?,
 	val certRenewalInfo: Map<String, Map<CertificateRenewalType, CertificateRenewalInfoModel>>?,
-	val showValiditySince: Boolean?,
+	val showValidityState: Boolean?,
 ) {
 	fun getInfoBox(languageKey: String?): InfoBoxModel? = infoBox?.get(languageKey)
 	fun getQuestionsFaqs(languageKey: String): FaqModel? = questions?.get(languageKey)

--- a/common/src/main/java/ch/admin/bag/covidcertificate/common/extensions/DccCertExtensions.kt
+++ b/common/src/main/java/ch/admin/bag/covidcertificate/common/extensions/DccCertExtensions.kt
@@ -1,0 +1,19 @@
+package ch.admin.bag.covidcertificate.common.extensions
+
+import ch.admin.bag.covidcertificate.sdk.core.extensions.firstPositiveResult
+import ch.admin.bag.covidcertificate.sdk.core.extensions.vaccineDate
+import ch.admin.bag.covidcertificate.sdk.core.extensions.validFromDate
+import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.eu.DccCert
+import java.time.LocalDateTime
+
+fun DccCert.getDate(): LocalDateTime? {
+	var date = this.vaccinations?.firstOrNull()?.vaccineDate()
+
+	if (date == null) {
+		date = this.pastInfections?.firstOrNull()?.firstPositiveResult()
+	}
+	if (date == null) {
+		date = this.tests?.firstOrNull()?.validFromDate()
+	}
+	return date
+}

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -1458,7 +1458,6 @@ Dieses Zertifikat ist zeitlich nur begrenzt gültig. Die aktuell in der Schweiz 
     <string name="wallet_certificate_antigen_positive_date">"Datum des ersten positiven Resultats"</string>
 
     <!-- Wallet: Blaue Box für positiven Antigen-Test -->
-    <!-- Fuzzy -->
     <string name="wallet_certificate_detail_note_positive_antigen">"Dieses Zertifikat ist kein Reisedokument.
 &lt;br /&gt;&lt;br /&gt;
 Dieses Zertifikat ist zeitlich nur begrenzt gültig. Die aktuell in der Schweiz massgebliche Gültigkeitsdauer können Sie jederzeit mit der Covid-Certificate App überprüfen."</string>
@@ -1482,7 +1481,6 @@ Dieses Zertifikat ist zeitlich nur begrenzt gültig. Die aktuell in der Schweiz 
     <string name="wallet_eol_banner_invalid_in_three_weeks_popup_text1"></string>
 
     <!-- bold text box for pop up. case: certificate will be invalid within three weeks of validity change. -->
-    <!-- Fuzzy -->
     <string name="wallet_eol_banner_invalid_in_three_weeks_popup_bold_text">"Dieses Covid-Zertifikat ist nur noch wenige Tage gültig. Bitte beachten Sie das auf dem Zertifikat ausgewiesene Ablaufdatum."</string>
 
     <!-- link text for pop up. case: certificate will be invalid within three weeks of validity change. -->
@@ -1507,7 +1505,6 @@ Dieses Zertifikat ist zeitlich nur begrenzt gültig. Die aktuell in der Schweiz 
     <string name="wallet_eol_banner_invalid_from_first_february_popup_title">"Info"</string>
 
     <!-- text for pop up. case: certificate will be invalid at time of validity change. -->
-    <!-- Fuzzy -->
     <string name="wallet_eol_banner_invalid_from_first_february_popup_text1">"Per 31. Jan. 2022 gelten in der Schweiz reduzierte Gültigkeitsdauern von 270 statt 365 Tagen für Covid-Zertifikate für Geimpfte oder Genesene. Dieses Zertifikat ist von der verkürzten Gültigkeitsdauer unmittelbar betroffen:"</string>
 
     <!-- bold text box for pop up. case: certificate will be invalid at time of validity change. -->
@@ -1521,21 +1518,11 @@ Dieses Zertifikat ist zeitlich nur begrenzt gültig. Die aktuell in der Schweiz 
 
     <!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
     <string name="wallet_eol_banner_invalid_in_three_weeks_popup_text2"></string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_title">"Zertifikat sichern!"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_text">"Wenn Sie die App löschen, Ihr Smartphone wechseln oder verlieren, gehen auch Ihre Covid-Zertifikate verloren.
 Bewahren Sie Ihre Zertifikate daher auch ausserhalb der App auf, indem Sie diese als PDF exportieren."</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_button">"Mehr erfahren"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_android">"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_ios">"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate"</string>
 
     <!-- accessibilityLabel for the "1"-icon -->
@@ -1599,15 +1586,12 @@ Bewahren Sie Ihre Zertifikate daher auch ausserhalb der App auf, indem Sie diese
     <string name="wallet_foreign_rules_check_network_error_text">"Um die Gültigkeit zu überprüfen, muss Ihr Smartphone mit dem Internet verbunden sein."</string>
 
     <!-- Reisefeature: Hinweis 1 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_2">"Die Einreiseregeln können sich ändern. Prüfen Sie daher die Gültigkeit kurz vor der Abreise und informieren Sie sich zusätzlich online über die aktuellen Einreiseregeln des Ziellandes."</string>
 
     <!-- Reisefeature: Hinweis 2 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_3">"Die oben genannten Angaben beziehen sich nur auf die Einreiseregeln des Ziellandes. Für allfällige zertifikatspflichtige Bereiche innerhalb des Landes können andere Regeln gelten."</string>
 
     <!-- Reisefeature: Hinweis 3 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_1">"Für die Aktualität und Vollständigkeit der gegebenen Informationen übernimmt der Bund keine Haftung."</string>
 
     <!-- Reisefeature: Hinweis 4 -->
@@ -1655,7 +1639,6 @@ Sie haben die Möglichkeit, eine EU-kompatible Version dieses Zertifikats bei de
     <string name="rat_conversion_info2_text">"Durch die Übernahme der Daten des Zertifikats in das Online-Formular kann Ihr Antrag einfacher verarbeitet werden."</string>
 
     <!-- Die URL für das Formular, mit dem für ein RAT Genesungszert ein reguläres Genesungszert beantragt werden kann -->
-    <!-- Fuzzy -->
     <string name="wallet_rat_recovery_conversion_url">"https://covidcertificate-form.admin.ch/immunityrequest"</string>
 
     <!-- RAT-Umwandlung: Titel vor Infos -->
@@ -1734,7 +1717,6 @@ Sie haben die Möglichkeit, eine EU-kompatible Version dieses Zertifikats bei de
     <string name="wallet_certificate_renewal_successful_bubble_button">"Mehr erfahren"</string>
 
     <!-- Wallet: QR Code des Zertifikats abgelaufen -->
-    <!-- Fuzzy -->
     <string name="wallet_error_qr_code_expired">"Das technische Ablaufdatum für diesen QR-Code ist erreicht."</string>
     <string name="wallet_certificate_renewal_rate_limit_error_title">"24h-Limite erreicht"</string>
     <string name="wallet_certificate_renewal_rate_limit_error_text">"QR-Code zu oft erneuert. Erneuerung temporär gesperrt."</string>
@@ -1742,4 +1724,21 @@ Sie haben die Möglichkeit, eine EU-kompatible Version dieses Zertifikats bei de
     <string name="wallet_certificate_renewal_faq_link_url">"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/wieso-soll-ich-den-qr-code-meines-covid-zertifikats-erneuern-obwohl-das-zertifikat"</string>
     <string name="terms_and_conditions_update_boarding_title">"Aktualisierung"</string>
     <string name="terms_and_conditions_update_boarding_text">"Die Nutzungsbedingungen und die Datenschutzerklärung der App wurden punktuell aktualisiert und an die rechtlichen Grundlagen angepasst."</string>
+    <string name="wallet_validity_since_vaccination_date">"Impfdatum"</string>
+    <string name="wallet_validity_since_test_date">"Testdatum"</string>
+
+    <!-- vor 2 Tagen - must be before "2 Tagen"! -->
+    <string name="wallet_validity_since_prefix">"vor"</string>
+
+    <!-- vor 1 Stunde -->
+    <string name="wallet_validity_since_hours_singular">"1 Stunde"</string>
+
+    <!-- vor 2 Stunden -->
+    <string name="wallet_validity_since_hours_plural">"{HOURS} Stunden"</string>
+
+    <!-- vor 1 Tag -->
+    <string name="wallet_validity_since_days_singular">"1 Tag"</string>
+
+    <!-- vor 2 Tagen -->
+    <string name="wallet_validity_since_days_plural">"{DAYS} Tagen"</string>
 </resources>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -1725,10 +1725,12 @@ Sie haben die Möglichkeit, eine EU-kompatible Version dieses Zertifikats bei de
     <string name="terms_and_conditions_update_boarding_title">"Aktualisierung"</string>
     <string name="terms_and_conditions_update_boarding_text">"Die Nutzungsbedingungen und die Datenschutzerklärung der App wurden punktuell aktualisiert und an die rechtlichen Grundlagen angepasst."</string>
     <string name="wallet_validity_since_vaccination_date">"Impfdatum"</string>
-    <string name="wallet_validity_since_test_date">"Testdatum"</string>
+    <string name="wallet_validity_since_test_date">"Negativ getestet"</string>
+    <string name="wallet_validity_since_recovery_date">"Positiv getestet"</string>
 
     <!-- vor 2 Tagen - must be before "2 Tagen"! -->
     <string name="wallet_validity_since_prefix">"vor"</string>
+    <string name="wallet_validity_since_more_hours_prefix">"vor mehr als"</string>
 
     <!-- vor 1 Stunde -->
     <string name="wallet_validity_since_hours_singular">"1 Stunde"</string>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -1720,6 +1720,8 @@ Vous avez la possibilité de demander une version de ce certificat compatible av
     <string name="terms_and_conditions_update_boarding_text">"Les conditions d’utilisation et la politique de confidentialité de l’application ont été ponctuellement mises à jour et adaptées aux bases légales."</string>
     <string name="wallet_validity_since_vaccination_date"></string>
     <string name="wallet_validity_since_test_date"></string>
+    <string name="wallet_validity_since_more_hours_prefix"></string>
+    <string name="wallet_validity_since_recovery_date"></string>
 
     <!-- vor 2 Tagen - must be before "2 Tagen"! -->
     <string name="wallet_validity_since_prefix"></string>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -1452,7 +1452,6 @@ Ce certificat n'a qu'une durée de validité limitée. L'application «COVID Cer
     <string name="wallet_certificate_antigen_positive_date">"Date du premier résultat positif"</string>
 
     <!-- Wallet: Blaue Box für positiven Antigen-Test -->
-    <!-- Fuzzy -->
     <string name="wallet_certificate_detail_note_positive_antigen">"Le présent certificat n'est pas un document de voyage.
 &lt;br /&gt;&lt;br /&gt;
 Ce certificat n'a qu'une durée de validité limitée. L'application «COVID Certificate» vous permet en tout temps de vérifier la durée de validité actuellement déterminante en Suisse."</string>
@@ -1513,21 +1512,11 @@ Ce certificat n'a qu'une durée de validité limitée. L'application «COVID Cer
 
     <!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
     <string name="wallet_eol_banner_invalid_in_three_weeks_popup_text2"></string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_title">"Sauvegardez vos certificats!"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_text">"Si vous supprimez l’application, changez de smartphone ou le perdez, vos certificats COVID seront également perdus.
 Conservez donc vos certificats en dehors de l’application en les exportant au format PDF."</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_button">"Plus d’informations"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_android">"https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/mon-certificat-covid-nest-disponible-quau-format-electronique-dans-lapplication"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_ios">"https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/mon-certificat-covid-nest-disponible-quau-format-electronique-dans-lapplication"</string>
 
     <!-- accessibilityLabel for the "1"-icon -->
@@ -1591,15 +1580,12 @@ Conservez donc vos certificats en dehors de l’application en les exportant au 
     <string name="wallet_foreign_rules_check_network_error_text">"Pour vérifier la validité, votre smartphone doit être connecté à Internet."</string>
 
     <!-- Reisefeature: Hinweis 1 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_2">"Les dispositions d’entrée peuvent changer. Vérifiez donc la validité de votre certificat avant votre départ et renseignez-vous également en ligne sur les dispositions d’entrée en vigueur dans votre pays de destination."</string>
 
     <!-- Reisefeature: Hinweis 2 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_3">"Les informations ci-dessus ne concernent que les dispositions d’entrée du pays de destination. Dans le pays, d’autres règles peuvent s’appliquer aux éventuels domaines soumis à l’obligation de présenter un certificat."</string>
 
     <!-- Reisefeature: Hinweis 3 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_1">"La Confédération décline toute responsabilité en ce qui concerne l’actualité et l’exhaustivité des informations fournies."</string>
 
     <!-- Reisefeature: Hinweis 4 -->
@@ -1647,7 +1633,6 @@ Vous avez la possibilité de demander une version de ce certificat compatible av
     <string name="rat_conversion_info2_text">"Le transfert des données du certificat dans le formulaire en ligne permet de faciliter le traitement de votre demande."</string>
 
     <!-- Die URL für das Formular, mit dem für ein RAT Genesungszert ein reguläres Genesungszert beantragt werden kann -->
-    <!-- Fuzzy -->
     <string name="wallet_rat_recovery_conversion_url">"https://covidcertificate-form.admin.ch/immunityrequest"</string>
 
     <!-- RAT-Umwandlung: Titel vor Infos -->
@@ -1726,7 +1711,6 @@ Vous avez la possibilité de demander une version de ce certificat compatible av
     <string name="wallet_certificate_renewal_successful_bubble_button">"En savoir plus"</string>
 
     <!-- Wallet: QR Code des Zertifikats abgelaufen -->
-    <!-- Fuzzy -->
     <string name="wallet_error_qr_code_expired">"La date d’expiration technique de ce code QR est atteinte."</string>
     <string name="wallet_certificate_renewal_rate_limit_error_title">"Limite des 24 heures atteinte"</string>
     <string name="wallet_certificate_renewal_rate_limit_error_text">"Le code QR a été renouvelé trop souvent. Le renouvellement est temporairement bloqué."</string>
@@ -1734,4 +1718,21 @@ Vous avez la possibilité de demander une version de ce certificat compatible av
     <string name="wallet_certificate_renewal_faq_link_url">"https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/fr/certificat-covid/pourquoi-dois-je-renouveler-le-code-qr-de-mon-certificat-covid-alors-que-selon-les"</string>
     <string name="terms_and_conditions_update_boarding_title">"Mise à jour"</string>
     <string name="terms_and_conditions_update_boarding_text">"Les conditions d’utilisation et la politique de confidentialité de l’application ont été ponctuellement mises à jour et adaptées aux bases légales."</string>
+    <string name="wallet_validity_since_vaccination_date"></string>
+    <string name="wallet_validity_since_test_date"></string>
+
+    <!-- vor 2 Tagen - must be before "2 Tagen"! -->
+    <string name="wallet_validity_since_prefix"></string>
+
+    <!-- vor 1 Stunde -->
+    <string name="wallet_validity_since_hours_singular"></string>
+
+    <!-- vor 2 Stunden -->
+    <string name="wallet_validity_since_hours_plural"></string>
+
+    <!-- vor 1 Tag -->
+    <string name="wallet_validity_since_days_singular"></string>
+
+    <!-- vor 2 Tagen -->
+    <string name="wallet_validity_since_days_plural"></string>
 </resources>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -1725,6 +1725,8 @@ Conservate quindi i vostri certificati anche al di fuori dell’app esportandoli
     <string name="terms_and_conditions_update_boarding_text">"L’informativa sulla privacy (dichiarazione sulla protezione dei dati) e le condizioni d’uso dell’app sono state puntualmente aggiornate e adeguate alle basi legali."</string>
     <string name="wallet_validity_since_vaccination_date"></string>
     <string name="wallet_validity_since_test_date"></string>
+    <string name="wallet_validity_since_more_hours_prefix"></string>
+    <string name="wallet_validity_since_recovery_date"></string>
 
     <!-- vor 2 Tagen - must be before "2 Tagen"! -->
     <string name="wallet_validity_since_prefix"></string>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -1457,7 +1457,6 @@ Questo certificato ha soltanto una validità temporanea. L'applicazione «COVID 
     <string name="wallet_certificate_antigen_positive_date">"Data del primo risultato positivo"</string>
 
     <!-- Wallet: Blaue Box für positiven Antigen-Test -->
-    <!-- Fuzzy -->
     <string name="wallet_certificate_detail_note_positive_antigen">"La presente attestazione non costituisce un documento di viaggio.
 &lt;br /&gt;&lt;br /&gt;
 Questo certificato ha soltanto una validità temporanea. L'applicazione «COVID Certificate» consente di verificare in qualsiasi momento l'attuale durata di validità in Svizzera."</string>
@@ -1518,21 +1517,11 @@ Questo certificato ha soltanto una validità temporanea. L'applicazione «COVID 
 
     <!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
     <string name="wallet_eol_banner_invalid_in_three_weeks_popup_text2"></string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_title">"Mettete al sicuro il vostro certificato!"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_text">"Se cancellate l’app, cambiate o smarrite il vostro smartphone, anche i vostri certificati COVID andranno persi. 
 Conservate quindi i vostri certificati anche al di fuori dell’app esportandoli in formato PDF."</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_button">"Per maggiori informazioni"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_android">"https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/ho-il-certificato-covid-esclusivamente-formato-elettronico-nellapp-covid"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_ios">"https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/ho-il-certificato-covid-esclusivamente-formato-elettronico-nellapp-covid"</string>
 
     <!-- accessibilityLabel for the "1"-icon -->
@@ -1596,15 +1585,12 @@ Conservate quindi i vostri certificati anche al di fuori dell’app esportandoli
     <string name="wallet_foreign_rules_check_network_error_text">"Per poter verificare la validità, lo smartphone deve essere collegato a Internet."</string>
 
     <!-- Reisefeature: Hinweis 1 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_2">"Le disposizioni d’entrata possono cambiare. Verificate poco prima della partenza se il vostro certificato è valido e informatevi ulteriormente online sulle disposizioni d’entrata attuali del Paese di destinazione."</string>
 
     <!-- Reisefeature: Hinweis 2 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_3">"Le informazioni sopra indicate si riferiscono solo alle disposizioni d’entrata del Paese di destinazione. Per eventuali settori soggetti all’obbligo di certificato all’interno del Paese possono vigere altre regole."</string>
 
     <!-- Reisefeature: Hinweis 3 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_1">"La Confederazione non si assume la responsabilità per l’attualità e la completezza delle informazioni fornite."</string>
 
     <!-- Reisefeature: Hinweis 4 -->
@@ -1652,7 +1638,6 @@ Conservate quindi i vostri certificati anche al di fuori dell’app esportandoli
     <string name="rat_conversion_info2_text">"Con il trasferimento dei dati del certificato nel modulo online, la richiesta può essere elaborata più semplicemente."</string>
 
     <!-- Die URL für das Formular, mit dem für ein RAT Genesungszert ein reguläres Genesungszert beantragt werden kann -->
-    <!-- Fuzzy -->
     <string name="wallet_rat_recovery_conversion_url">"https://covidcertificate-form.admin.ch/immunityrequest"</string>
 
     <!-- RAT-Umwandlung: Titel vor Infos -->
@@ -1731,7 +1716,6 @@ Conservate quindi i vostri certificati anche al di fuori dell’app esportandoli
     <string name="wallet_certificate_renewal_successful_bubble_button">"Per saperne di più"</string>
 
     <!-- Wallet: QR Code des Zertifikats abgelaufen -->
-    <!-- Fuzzy -->
     <string name="wallet_error_qr_code_expired">"La data di scadenza tecnica di questo codice QR sarà raggiunta."</string>
     <string name="wallet_certificate_renewal_rate_limit_error_title">"È stato raggiunto il limite di 24 ore"</string>
     <string name="wallet_certificate_renewal_rate_limit_error_text">"Codice QR rinnovato troppo spesso. Rinnovo temporaneamente bloccato."</string>
@@ -1739,4 +1723,21 @@ Conservate quindi i vostri certificati anche al di fuori dell’app esportandoli
     <string name="wallet_certificate_renewal_faq_link_url">"https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/it/certificato-covid/perche-devo-rinnovare-il-codice-qr-del-mio-certificato-covid-anche-se-secondo-le"</string>
     <string name="terms_and_conditions_update_boarding_title">"Aggiornamento"</string>
     <string name="terms_and_conditions_update_boarding_text">"L’informativa sulla privacy (dichiarazione sulla protezione dei dati) e le condizioni d’uso dell’app sono state puntualmente aggiornate e adeguate alle basi legali."</string>
+    <string name="wallet_validity_since_vaccination_date"></string>
+    <string name="wallet_validity_since_test_date"></string>
+
+    <!-- vor 2 Tagen - must be before "2 Tagen"! -->
+    <string name="wallet_validity_since_prefix"></string>
+
+    <!-- vor 1 Stunde -->
+    <string name="wallet_validity_since_hours_singular"></string>
+
+    <!-- vor 2 Stunden -->
+    <string name="wallet_validity_since_hours_plural"></string>
+
+    <!-- vor 1 Tag -->
+    <string name="wallet_validity_since_days_singular"></string>
+
+    <!-- vor 2 Tagen -->
+    <string name="wallet_validity_since_days_plural"></string>
 </resources>

--- a/common/src/main/res/values-rm/strings.xml
+++ b/common/src/main/res/values-rm/strings.xml
@@ -1452,7 +1452,6 @@ Quest certificat è valaivel mo per in tschert temp. La durada da valaivladad ac
     <string name="wallet_certificate_antigen_positive_date">"Data da l'emprim resultat positiv"</string>
 
     <!-- Wallet: Blaue Box für positiven Antigen-Test -->
-    <!-- Fuzzy -->
     <string name="wallet_certificate_detail_note_positive_antigen">"Quest attest n'è betg in document da viadi.
 &lt;br /&gt;&lt;br /&gt;
 Quest certificat è valaivel mo per in tschert temp. La durada da valaivladad actuala en Svizra pudais Vus verifitgar da tut temp cun l'app «Covid-Certificate»."</string>
@@ -1513,21 +1512,11 @@ Quest certificat è valaivel mo per in tschert temp. La durada da valaivladad ac
 
     <!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
     <string name="wallet_eol_banner_invalid_in_three_weeks_popup_text2"></string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_title">"Tegnair en salv il certificat!"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_text">"Sche Vus stizzais l'app, midais u perdais Voss smartphone, van er a perder Voss certificats COVID. 
 Tegnai perquai en salv Voss certificats er ordaifer l'app cun exportar quels sco PDF."</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_button">"Dapli infurmaziuns"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_android">"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_ios">"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/ich-habe-das-covid-zertifikat-ausschliesslich-elektronisch-der-covid-certificate"</string>
 
     <!-- accessibilityLabel for the "1"-icon -->
@@ -1591,15 +1580,12 @@ Tegnai perquai en salv Voss certificats er ordaifer l'app cun exportar quels sco
     <string name="wallet_foreign_rules_check_network_error_text">"Per verifitgar la valaivladad sto Voss smartphone esser collià cun l’internet."</string>
 
     <!-- Reisefeature: Hinweis 1 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_2">"Las reglas d'entrada pon sa midar. Verifitgai perquai la valaivladad curt avant che Vus partis ed As infurmai ultra da quai online davart las reglas d'entrada actualas dal pajais da destinaziun."</string>
 
     <!-- Reisefeature: Hinweis 2 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_3">"Las infurmaziuns qua survart sa refereschan mo a las reglas d'entrada dal pajais da destinaziun. Per secturs che pretendan eventualmain in certificat entaifer il pajais pon valair autras reglas."</string>
 
     <!-- Reisefeature: Hinweis 3 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_1">"Per l'actualitad e la cumplettadad da las infurmaziuns na surpiglia la Confederaziun nagina responsabladad."</string>
 
     <!-- Reisefeature: Hinweis 4 -->
@@ -1647,7 +1633,6 @@ Per quest certificat pudais Vus dumandar ina versiun cumpatibla cun il certifica
     <string name="rat_conversion_info2_text">"Cun transferir las datas dal certificat en il formular online po Vossa dumonda vegnir tractada en moda pli simpla."</string>
 
     <!-- Die URL für das Formular, mit dem für ein RAT Genesungszert ein reguläres Genesungszert beantragt werden kann -->
-    <!-- Fuzzy -->
     <string name="wallet_rat_recovery_conversion_url">"https://covidcertificate-form.admin.ch/immunityrequest"</string>
 
     <!-- RAT-Umwandlung: Titel vor Infos -->
@@ -1726,7 +1711,6 @@ Per quest certificat pudais Vus dumandar ina versiun cumpatibla cun il certifica
     <string name="wallet_certificate_renewal_successful_bubble_button">"Dapli infurmaziuns"</string>
 
     <!-- Wallet: QR Code des Zertifikats abgelaufen -->
-    <!-- Fuzzy -->
     <string name="wallet_error_qr_code_expired">"La data da la scadenza tecnica da quest code QR è arrivada."</string>
     <string name="wallet_certificate_renewal_rate_limit_error_title">"La limita da 24 uras è cuntanschida"</string>
     <string name="wallet_certificate_renewal_rate_limit_error_text">"Code QR renovà memia savens. Renovaziun bloccada temporarmain."</string>
@@ -1734,4 +1718,21 @@ Per quest certificat pudais Vus dumandar ina versiun cumpatibla cun il certifica
     <string name="wallet_certificate_renewal_faq_link_url">"https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/de/covid-zertifikat/wieso-soll-ich-den-qr-code-meines-covid-zertifikats-erneuern-obwohl-das-zertifikat"</string>
     <string name="terms_and_conditions_update_boarding_title">"Actualisaziun"</string>
     <string name="terms_and_conditions_update_boarding_text">"Las cundiziuns d’utilisaziun e la decleraziun davart la protecziun da datas da l’app èn vegnidas actualisadas en tscherts puncts ed adattadas a las basas legalas. "</string>
+    <string name="wallet_validity_since_vaccination_date"></string>
+    <string name="wallet_validity_since_test_date"></string>
+
+    <!-- vor 2 Tagen - must be before "2 Tagen"! -->
+    <string name="wallet_validity_since_prefix"></string>
+
+    <!-- vor 1 Stunde -->
+    <string name="wallet_validity_since_hours_singular"></string>
+
+    <!-- vor 2 Stunden -->
+    <string name="wallet_validity_since_hours_plural"></string>
+
+    <!-- vor 1 Tag -->
+    <string name="wallet_validity_since_days_singular"></string>
+
+    <!-- vor 2 Tagen -->
+    <string name="wallet_validity_since_days_plural"></string>
 </resources>

--- a/common/src/main/res/values-rm/strings.xml
+++ b/common/src/main/res/values-rm/strings.xml
@@ -1720,6 +1720,8 @@ Per quest certificat pudais Vus dumandar ina versiun cumpatibla cun il certifica
     <string name="terms_and_conditions_update_boarding_text">"Las cundiziuns d’utilisaziun e la decleraziun davart la protecziun da datas da l’app èn vegnidas actualisadas en tscherts puncts ed adattadas a las basas legalas. "</string>
     <string name="wallet_validity_since_vaccination_date"></string>
     <string name="wallet_validity_since_test_date"></string>
+    <string name="wallet_validity_since_more_hours_prefix"></string>
+    <string name="wallet_validity_since_recovery_date"></string>
 
     <!-- vor 2 Tagen - must be before "2 Tagen"! -->
     <string name="wallet_validity_since_prefix"></string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-    <!--
+<?xml version="1.0" encoding="utf-8"?><!--
     ~ Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
     ~
     ~ This Source Code Form is subject to the terms of the Mozilla Public
@@ -10,1206 +9,1206 @@
     -->
 <resources>
 
-    <!-- Android App Name -->
-    <string name="verifier_app_name">"Covid Check"</string>
+	<!-- Android App Name -->
+	<string name="verifier_app_name">"Covid Check"</string>
 
-    <!-- Title for the qr scanning screen -->
-    <string name="verifier_title_qr_scan">"Verify"</string>
+	<!-- Title for the qr scanning screen -->
+	<string name="verifier_title_qr_scan">"Verify"</string>
 
-    <!-- Titel über dem Haupttitel -->
-    <string name="verifier_homescreen_header_title">"COVID certificate"</string>
+	<!-- Titel über dem Haupttitel -->
+	<string name="verifier_homescreen_header_title">"COVID certificate"</string>
 
-    <!-- Homescreen App Name -->
-    <string name="verifier_homescreen_title">"Check"</string>
+	<!-- Homescreen App Name -->
+	<string name="verifier_homescreen_title">"Check"</string>
 
-    <!-- Beschreibung für Pager Bild 1 -->
-    <string name="verifier_homescreen_pager_description_1">"Scan presented certificate"</string>
+	<!-- Beschreibung für Pager Bild 1 -->
+	<string name="verifier_homescreen_pager_description_1">"Scan presented certificate"</string>
 
-    <!-- Beschreibung für Pager Bild 2 -->
-    <string name="verifier_homescreen_pager_description_2">"Certificates are verified automatically"</string>
+	<!-- Beschreibung für Pager Bild 2 -->
+	<string name="verifier_homescreen_pager_description_2">"Certificates are verified automatically"</string>
 
-    <!-- Homescreen Button für Scanning -->
-    <string name="verifier_homescreen_scan_button">"Verify"</string>
+	<!-- Homescreen Button für Scanning -->
+	<string name="verifier_homescreen_scan_button">"Verify"</string>
 
-    <!-- Homescreen Button für Support -->
-    <string name="verifier_homescreen_support_button">"How it works"</string>
-    <string name="error_network_title">"Network error"</string>
-    <string name="error_network_text">"Check your internet connection."</string>
-    <string name="error_action_retry">"Try again"</string>
-    <string name="error_camera_permission_title">"No access to camera"</string>
-    <string name="error_camera_permission_text">"The app requires access to the camera to be able to scan the QR code."</string>
-    <string name="error_action_change_settings">"Change settings"</string>
-    <string name="error_title">"Error"</string>
-    <string name="qr_scanner_error">"Invalid code"</string>
-    <string name="ok_button">"OK"</string>
-    <string name="camera_permission_dialog_text">"The app requires access to the camera to be able to scan the QR code."</string>
-    <string name="camera_permission_dialog_action">"Allow access to camera"</string>
-    <string name="verifier_qr_scanner_scan_qr_text">"Scan QR code 
+	<!-- Homescreen Button für Support -->
+	<string name="verifier_homescreen_support_button">"How it works"</string>
+	<string name="error_network_title">"Network error"</string>
+	<string name="error_network_text">"Check your internet connection."</string>
+	<string name="error_action_retry">"Try again"</string>
+	<string name="error_camera_permission_title">"No access to camera"</string>
+	<string name="error_camera_permission_text">"The app requires access to the camera to be able to scan the QR code."</string>
+	<string name="error_action_change_settings">"Change settings"</string>
+	<string name="error_title">"Error"</string>
+	<string name="qr_scanner_error">"Invalid code"</string>
+	<string name="ok_button">"OK"</string>
+	<string name="camera_permission_dialog_text">"The app requires access to the camera to be able to scan the QR code."</string>
+	<string name="camera_permission_dialog_action">"Allow access to camera"</string>
+	<string name="verifier_qr_scanner_scan_qr_text">"Scan QR code
 to verify"</string>
 
-    <!-- Titel auf dem Verifikations-Screen -->
-    <string name="covid_certificate_title">"COVID certificate"</string>
+	<!-- Titel auf dem Verifikations-Screen -->
+	<string name="covid_certificate_title">"COVID certificate"</string>
 
-    <!-- Name des/der Zertifikatsinhabers/Zertifikatsinhaberin -->
-    <string name="verifier_covid_certificate_name">"Last name"</string>
+	<!-- Name des/der Zertifikatsinhabers/Zertifikatsinhaberin -->
+	<string name="verifier_covid_certificate_name">"Last name"</string>
 
-    <!-- Geburtsdatum des/der Zertifikatsinhabers/Zertifikatsinhaberin -->
-    <string name="verifier_covid_certificate_birthdate">"Date of birth"</string>
+	<!-- Geburtsdatum des/der Zertifikatsinhabers/Zertifikatsinhaberin -->
+	<string name="verifier_covid_certificate_birthdate">"Date of birth"</string>
 
-    <!-- Wallet: Zertifikat hinzufügen -->
-    <string name="wallet_add_certificate">"Add"</string>
+	<!-- Wallet: Zertifikat hinzufügen -->
+	<string name="wallet_add_certificate">"Add"</string>
 
-    <!-- Wallet: Homescreen Covid-Zertifikat -->
-    <string name="wallet_certificate">"COVID certificate"</string>
+	<!-- Wallet: Homescreen Covid-Zertifikat -->
+	<string name="wallet_certificate">"COVID certificate"</string>
 
-    <!-- Wallet: Homescreen Erklärung -->
-    <string name="wallet_homescreen_explanation">"Scan the QR code on the COVID certificate to add it to the app."</string>
+	<!-- Wallet: Homescreen Erklärung -->
+	<string name="wallet_homescreen_explanation">"Scan the QR code on the COVID certificate to add it to the app."</string>
 
-    <!-- Wallet: Scanner Titel -->
-    <string name="wallet_scanner_title">"Add"</string>
+	<!-- Wallet: Scanner Titel -->
+	<string name="wallet_scanner_title">"Add"</string>
 
-    <!-- Titel bei erfolgreicher Prüfung -->
-    <string name="verifier_verify_success_title">"Verification successful"</string>
+	<!-- Titel bei erfolgreicher Prüfung -->
+	<string name="verifier_verify_success_title">"Verification successful"</string>
 
-    <!-- Info Text bei erfolgreicher Prüfung -->
-    <string name="verifier_verify_success_info">"Only valid in combination with 
+	<!-- Info Text bei erfolgreicher Prüfung -->
+	<string name="verifier_verify_success_info">"Only valid in combination with
 an identity document"</string>
 
-    <!-- Prüfung loading text -->
-    <string name="verifier_verify_loading_text">"Certificate is being verified"</string>
+	<!-- Prüfung loading text -->
+	<string name="verifier_verify_loading_text">"Certificate is being verified"</string>
 
-    <!-- Fehler Title bei Prüfung -->
-    <string name="verifier_verify_error_title">"COVID Certificate invalid"</string>
+	<!-- Fehler Title bei Prüfung -->
+	<string name="verifier_verify_error_title">"COVID Certificate invalid"</string>
 
-    <!-- Fehler Infotext bei Prüfung (Nationale Regeln) -->
-    <string name="verifier_verify_error_info_for_national_rules">"Does not meet the validity criteria for Switzerland or for the selected verification mode ({MODUS})"</string>
+	<!-- Fehler Infotext bei Prüfung (Nationale Regeln) -->
+	<string name="verifier_verify_error_info_for_national_rules">"Does not meet the validity criteria for Switzerland or for the selected verification mode ({MODUS})"</string>
 
-    <!-- Fehler Infotext bei Prüfung (Zertifikat Fehler) -->
-    <string name="verifier_verify_error_info_for_certificate_invalid">"The COVID certificate does not have a valid signature"</string>
+	<!-- Fehler Infotext bei Prüfung (Zertifikat Fehler) -->
+	<string name="verifier_verify_error_info_for_certificate_invalid">"The COVID certificate does not have a valid signature"</string>
 
-    <!-- Fehler Infotext bei Prüfung (Blacklist) -->
-    <string name="verifier_verify_error_info_for_blacklist">"The COVID certificate was revoked"</string>
+	<!-- Fehler Infotext bei Prüfung (Blacklist) -->
+	<string name="verifier_verify_error_info_for_blacklist">"The COVID certificate was revoked"</string>
 
-    <!-- Fehler bei der geladen Liste -->
-    <string name="verifier_verify_error_list_title">"Verification failed"</string>
+	<!-- Fehler bei der geladen Liste -->
+	<string name="verifier_verify_error_list_title">"Verification failed"</string>
 
-    <!-- Fehler Info bei laden der Liste -->
-    <string name="verifier_verify_error_list_info_text">"An unexpected error has occurred"</string>
+	<!-- Fehler Info bei laden der Liste -->
+	<string name="verifier_verify_error_list_info_text">"An unexpected error has occurred"</string>
 
-    <!-- Wallet: Scanner Text unten -->
-    <string name="wallet_scanner_explanation">"Scan the QR code on the COVID certificate."</string>
+	<!-- Wallet: Scanner Text unten -->
+	<string name="wallet_scanner_explanation">"Scan the QR code on the COVID certificate."</string>
 
-    <!-- Wallet: Scanner Info Button unten -->
-    <string name="wallet_scanner_info_button">"How it works"</string>
+	<!-- Wallet: Scanner Info Button unten -->
+	<string name="wallet_scanner_info_button">"How it works"</string>
 
-    <!-- Wallet: Erneut scannen Button -->
-    <string name="wallet_scan_again">"Scan again"</string>
+	<!-- Wallet: Erneut scannen Button -->
+	<string name="wallet_scan_again">"Scan again"</string>
 
-    <!-- Wallet: Hinzufügen von Zertifikat Button -->
-    <string name="wallet_add_certificate_button">"Add"</string>
+	<!-- Wallet: Hinzufügen von Zertifikat Button -->
+	<string name="wallet_add_certificate_button">"Add"</string>
 
-    <!-- Wallet: Titel der Liste Zertifikate -->
-    <string name="wallet_certificate_list_title">"Certificates"</string>
+	<!-- Wallet: Titel der Liste Zertifikate -->
+	<string name="wallet_certificate_list_title">"Certificates"</string>
 
-    <!-- Wallet: Löschen Button Titel -->
-    <string name="delete_button">"Delete"</string>
+	<!-- Wallet: Löschen Button Titel -->
+	<string name="delete_button">"Delete"</string>
 
-    <!-- Android App Name für die Wallet -->
-    <string name="wallet_app_name">"Covid Cert"</string>
+	<!-- Android App Name für die Wallet -->
+	<string name="wallet_app_name">"Covid Cert"</string>
 
-    <!-- Header im Onboarding-Screen "Die App" -->
-    <string name="wallet_onboarding_app_header">"The app"</string>
+	<!-- Header im Onboarding-Screen "Die App" -->
+	<string name="wallet_onboarding_app_header">"The app"</string>
 
-    <!-- Titel im Onboardingscreen "Die App" -->
-    <string name="wallet_onboarding_app_title">"COVID Certificate"</string>
+	<!-- Titel im Onboardingscreen "Die App" -->
+	<string name="wallet_onboarding_app_title">"COVID Certificate"</string>
 
-    <!-- Text im Onboardingscreen "Die App" -->
-    <string name="wallet_onboarding_app_text">"The app lets you store COVID certificates securely on your smartphone and present them easily."</string>
+	<!-- Text im Onboardingscreen "Die App" -->
+	<string name="wallet_onboarding_app_text">"The app lets you store COVID certificates securely on your smartphone and present them easily."</string>
 
-    <!-- Weiter-Button Titel -->
-    <string name="continue_button">"Next"</string>
+	<!-- Weiter-Button Titel -->
+	<string name="continue_button">"Next"</string>
 
-    <!-- Header im Onboarding-Screen "Datenschutz" -->
-    <string name="wallet_onboarding_privacy_header">"Data protection"</string>
+	<!-- Header im Onboarding-Screen "Datenschutz" -->
+	<string name="wallet_onboarding_privacy_header">"Data protection"</string>
 
-    <!-- Titel im Onboardingscreen "Datenschutz" -->
-    <string name="wallet_onboarding_privacy_title">"Your data remains 
+	<!-- Titel im Onboardingscreen "Datenschutz" -->
+	<string name="wallet_onboarding_privacy_title">"Your data remains
 in the app"</string>
 
-    <!-- Text im Onboardingscreen "Datenschutz" -->
-    <string name="wallet_onboarding_privacy_text">"The certificates are only saved locally on your smartphone. The data is not stored centrally."</string>
+	<!-- Text im Onboardingscreen "Datenschutz" -->
+	<string name="wallet_onboarding_privacy_text">"The certificates are only saved locally on your smartphone. The data is not stored centrally."</string>
 
-    <!-- Titel im Onboardingscreen "Vorteile, Vorweisen" -->
-    <string name="wallet_onboarding_show_title">"Present certificates simply"</string>
+	<!-- Titel im Onboardingscreen "Vorteile, Vorweisen" -->
+	<string name="wallet_onboarding_show_title">"Present certificates simply"</string>
 
-    <!-- Text 1 im Onboardingscreen "Vorteile, Vorweisen" -->
-    <string name="wallet_onboarding_show_text1">"The data in the COVID certificate is also contained in the QR code."</string>
+	<!-- Text 1 im Onboardingscreen "Vorteile, Vorweisen" -->
+	<string name="wallet_onboarding_show_text1">"The data in the COVID certificate is also contained in the QR code."</string>
 
-    <!-- Text 2 im Onboardingscreen "Vorteile, Vorweisen" -->
-    <string name="wallet_onboarding_show_text2">"On presentation, the QR code is scanned using a verifier app. The authenticity and validity of the data are automatically checked."</string>
+	<!-- Text 2 im Onboardingscreen "Vorteile, Vorweisen" -->
+	<string name="wallet_onboarding_show_text2">"On presentation, the QR code is scanned using a verifier app. The authenticity and validity of the data are automatically checked."</string>
 
-    <!-- Titel des Datenschutzerklärungs-Elements im Onboardingscreen "Datenschutz" -->
-    <string name="wallet_onboarding_privacy_privacypolicy_title">"Privacy policy"</string>
+	<!-- Titel des Datenschutzerklärungs-Elements im Onboardingscreen "Datenschutz" -->
+	<string name="wallet_onboarding_privacy_privacypolicy_title">"Privacy policy"</string>
 
-    <!-- Titel des Nutzungsbedingungen-Elements im Onboardingscreen "Datenschutz" -->
-    <string name="wallet_onboarding_privacy_conditionsofuse_title">"Terms of use"</string>
+	<!-- Titel des Nutzungsbedingungen-Elements im Onboardingscreen "Datenschutz" -->
+	<string name="wallet_onboarding_privacy_conditionsofuse_title">"Terms of use"</string>
 
-    <!-- Button zum Abschliessen des Onboardings -->
-    <string name="wallet_onboarding_accept_button">"Accept"</string>
-    <string name="language_key">"en"</string>
+	<!-- Button zum Abschliessen des Onboardings -->
+	<string name="wallet_onboarding_accept_button">"Accept"</string>
+	<string name="language_key">"en"</string>
 
-    <!-- Header im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_header">"How it works"</string>
+	<!-- Header im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_header">"How it works"</string>
 
-    <!-- Titel im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_title">"Add COVID certificates"</string>
+	<!-- Titel im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_title">"Add COVID certificates"</string>
 
-    <!-- Textblock 1 im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_text1">"To be able to add a COVID certificate to the app, you need the original certificate on paper or as a PDF."</string>
+	<!-- Textblock 1 im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_text1">"To be able to add a COVID certificate to the app, you need the original certificate on paper or as a PDF."</string>
 
-    <!-- Textblock 2 im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_text2">"Tap 'Add' in the app to add a new certificate."</string>
+	<!-- Textblock 2 im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_text2">"Tap 'Add' in the app to add a new certificate."</string>
 
-    <!-- Textblock 3 im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_text3">"Hold your smartphone camera over the QR code on the original certificate to scan it."</string>
+	<!-- Textblock 3 im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_text3">"Hold your smartphone camera over the QR code on the original certificate to scan it."</string>
 
-    <!-- Textblock 4 im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_text4">"A preview of the COVID certificate will appear. Tap 'Add' to securely add the certificate to the app."</string>
+	<!-- Textblock 4 im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_text4">"A preview of the COVID certificate will appear. Tap 'Add' to securely add the certificate to the app."</string>
 
-    <!-- Frage 1 im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_question1">"When and where can I get a COVID certificate?"</string>
+	<!-- Frage 1 im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_question1">"When and where can I get a COVID certificate?"</string>
 
-    <!-- Header im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_header">"FAQs"</string>
+	<!-- Header im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_header">"FAQs"</string>
 
-    <!-- Titel 1 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_title">"What are COVID certificates?"</string>
+	<!-- Titel 1 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_title">"What are COVID certificates?"</string>
 
-    <!-- Text 1im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_subtitle">"The COVID certificate makes it possible to document a COVID-19 vaccination, recovery from the virus or a negative test result in a forgery-proof manner."</string>
+	<!-- Text 1im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_subtitle">"The COVID certificate makes it possible to document a COVID-19 vaccination, recovery from the virus or a negative test result in a forgery-proof manner."</string>
 
-    <!-- Frage 1 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_question_1">"When and where can I get a COVID certificate?"</string>
+	<!-- Frage 1 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_question_1">"When and where can I get a COVID certificate?"</string>
 
-    <!-- Frage 2 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_question_2">"How can I present a COVID certificate?"</string>
+	<!-- Frage 2 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_question_2">"How can I present a COVID certificate?"</string>
 
-    <!-- Frage 3 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_question_3">"Where is my data stored?"</string>
+	<!-- Frage 3 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_question_3">"Where is my data stored?"</string>
 
-    <!-- Frage 4 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_question_4">"How are misuse and forgery prevented?"</string>
+	<!-- Frage 4 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_question_4">"How are misuse and forgery prevented?"</string>
 
-    <!-- Frage 5 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_question_5">"What happens if I lose my COVID certificate?"</string>
+	<!-- Frage 5 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_question_5">"What happens if I lose my COVID certificate?"</string>
 
-    <!-- Frage 6 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_question_1">"How can I add a COVID certificate to the app?"</string>
+	<!-- Frage 6 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_question_1">"How can I add a COVID certificate to the app?"</string>
 
-    <!-- Frage 7 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_question_2">"Can several COVID certificates be added?"</string>
+	<!-- Frage 7 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_question_2">"Can several COVID certificates be added?"</string>
 
-    <!-- Frage 8 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_question_3">"How can I see if my COVID certificate is valid?"</string>
+	<!-- Frage 8 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_question_3">"How can I see if my COVID certificate is valid?"</string>
 
-    <!-- Frage 9 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_question_4">"How is my data protected?"</string>
+	<!-- Frage 9 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_question_4">"How is my data protected?"</string>
 
-    <!-- Frage 10 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_question_5">"What data is contained in the QR code?"</string>
+	<!-- Frage 10 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_question_5">"What data is contained in the QR code?"</string>
 
-    <!-- Frage 11 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_question_6">"What do I need to do if I delete the COVID certificate or the app?"</string>
+	<!-- Frage 11 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_question_6">"What do I need to do if I delete the COVID certificate or the app?"</string>
 
-    <!-- Antwort 1 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_answer_1">"You can get a COVID certificate after a complete COVID-19 vaccination, after you have recovered from the virus or after you have tested negative. The certificate is generally issued upon request by health care professionals on site."</string>
+	<!-- Antwort 1 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_answer_1">"You can get a COVID certificate after a complete COVID-19 vaccination, after you have recovered from the virus or after you have tested negative. The certificate is generally issued upon request by health care professionals on site."</string>
 
-    <!-- Antwort 2 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_answer_2">"You can present your COVID certificate in paper form, or you can use the COVID Certificate app to save certificates in the dedicated app. You are free to choose whether to present your certificate in paper form or in the app.
+	<!-- Antwort 2 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_answer_2">"You can present your COVID certificate in paper form, or you can use the COVID Certificate app to save certificates in the dedicated app. You are free to choose whether to present your certificate in paper form or in the app.
 
 Please note that you will also need to show an identification document (passport or ID card) in either case.
 "</string>
 
-    <!-- Antwort 3 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_answer_3">"Your data is not stored in a central system, but only locally on your mobile device or in the QR code in the case of the paper COVID certificate."</string>
+	<!-- Antwort 3 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_answer_3">"Your data is not stored in a central system, but only locally on your mobile device or in the QR code in the case of the paper COVID certificate."</string>
 
-    <!-- Antwort 4 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_answer_4">"The COVID certificate QR code contains an electronic signature. This is an important security feature and makes the COVID certificate forgery-proof. Moreover, the COVID certificate is valid only in combination with an identification document (passport or ID card)."</string>
+	<!-- Antwort 4 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_answer_4">"The COVID certificate QR code contains an electronic signature. This is an important security feature and makes the COVID certificate forgery-proof. Moreover, the COVID certificate is valid only in combination with an identification document (passport or ID card)."</string>
 
-    <!-- Antwort 5 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_questions_answer_5">"Your COVID-19 certificate is not stored in any central system. It is solely in your possession. Therefore, keep your paper and/or PDF COVID-19 certificate in a safe place. If you lose your certificate and need to replace it, a fee may be charged."</string>
+	<!-- Antwort 5 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_questions_answer_5">"Your COVID-19 certificate is not stored in any central system. It is solely in your possession. Therefore, keep your paper and/or PDF COVID-19 certificate in a safe place. If you lose your certificate and need to replace it, a fee may be charged."</string>
 
-    <!-- Antwort 6 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_answer_1">"To add a COVID certificate to the app, you need the original certificate issued to you on paper or as a PDF document. You can use the COVID certificate app to scan the QR code on the original and add it to the app. The COVID certificate will then appear directly in the app."</string>
+	<!-- Antwort 6 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_answer_1">"To add a COVID certificate to the app, you need the original certificate issued to you on paper or as a PDF document. You can use the COVID certificate app to scan the QR code on the original and add it to the app. The COVID certificate will then appear directly in the app."</string>
 
-    <!-- Antwort 7 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_answer_2">"Yes, that is possible. For example, you can save the COVID certificates of all family members in your app. Also in this case, each COVID certificate is valid only in combination with an identification document (passport or ID card) of the certificate holder."</string>
+	<!-- Antwort 7 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_answer_2">"Yes, that is possible. For example, you can save the COVID certificates of all family members in your app. Also in this case, each COVID certificate is valid only in combination with an identification document (passport or ID card) of the certificate holder."</string>
 
-    <!-- Antwort 8 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_answer_3">"The app automatically checks whether your certificate meets Switzerland's validity criteria. If your COVID certificate has expired or is technically invalid, this is indicated directly on the certificate in the app. "</string>
+	<!-- Antwort 8 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_answer_3">"The app automatically checks whether your certificate meets Switzerland's validity criteria. If your COVID certificate has expired or is technically invalid, this is indicated directly on the certificate in the app. "</string>
 
-    <!-- Antwort 9 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_answer_4">"Your personal data is not stored in a central system; instead, it can be found solely locally on the mobile device or in the QR code in the case of the paper COVID certificate."</string>
+	<!-- Antwort 9 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_answer_4">"Your personal data is not stored in a central system; instead, it can be found solely locally on the mobile device or in the QR code in the case of the paper COVID certificate."</string>
 
-    <!-- Antwort 10 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_answer_5">"The QR code contains all the information that is found in plain text on your paper COVID certificate. The QR code also contains an electronic signature that can be used to check the authenticity of the COVID certificate. This makes the COVID certificate forgery-proof."</string>
+	<!-- Antwort 10 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_answer_5">"The QR code contains all the information that is found in plain text on your paper COVID certificate. The QR code also contains an electronic signature that can be used to check the authenticity of the COVID certificate. This makes the COVID certificate forgery-proof."</string>
 
-    <!-- Antwort 11 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_answer_6">"You can easily restore your COVID certificate on your mobile device. To do so, download the app again and then scan the QR code on your paper or PDF COVID certificate."</string>
+	<!-- Antwort 11 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_answer_6">"You can easily restore your COVID certificate on your mobile device. To do so, download the app again and then scan the QR code on your paper or PDF COVID certificate."</string>
 
-    <!-- Titel 2 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_title">"How the app works"</string>
+	<!-- Titel 2 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_title">"How the app works"</string>
 
-    <!-- Text 2 im FAQ-Screen der Wallet App -->
-    <string name="wallet_faq_works_subtitle">"With the COVID Certificate app, you can easily and securely store and present COVID certificates on your mobile device."</string>
+	<!-- Text 2 im FAQ-Screen der Wallet App -->
+	<string name="wallet_faq_works_subtitle">"With the COVID Certificate app, you can easily and securely store and present COVID certificates on your mobile device."</string>
 
-    <!-- Antwort 1 im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_answer1">"You can get a COVID certificate after a complete COVID-19 vaccination, after you have recovered from the virus or after you have tested negative. The certificate is generally issued upon request by health care professionals on site."</string>
+	<!-- Antwort 1 im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_answer1">"You can get a COVID certificate after a complete COVID-19 vaccination, after you have recovered from the virus or after you have tested negative. The certificate is generally issued upon request by health care professionals on site."</string>
 
-    <!-- Verifier: Detail Check Vorname -->
-    <string name="verifier_covid_certificate_prename">"First name"</string>
+	<!-- Verifier: Detail Check Vorname -->
+	<string name="verifier_covid_certificate_prename">"First name"</string>
 
-    <!-- Config: Titel wenn App muss geupdatet werden -->
-    <string name="force_update_title">"Update required"</string>
+	<!-- Config: Titel wenn App muss geupdatet werden -->
+	<string name="force_update_title">"Update required"</string>
 
-    <!-- Config: Text der angezeigt wird falls App muss geupdatet werden -->
-    <string name="force_update_text">"Download the latest version of the app."</string>
+	<!-- Config: Text der angezeigt wird falls App muss geupdatet werden -->
+	<string name="force_update_text">"Download the latest version of the app."</string>
 
-    <!-- Config: Update Button Aktualisieren -->
-    <string name="force_update_button">"Update"</string>
+	<!-- Config: Update Button Aktualisieren -->
+	<string name="force_update_button">"Update"</string>
 
-    <!-- Wallet: Zertifikat gültig ab: {DATE} -->
-    <string name="wallet_certificate_valid_from">"Valid in Switzerland from:
+	<!-- Wallet: Zertifikat gültig ab: {DATE} -->
+	<string name="wallet_certificate_valid_from">"Valid in Switzerland from:
 {DATE}"</string>
 
-    <!-- Wallet: Zertifikat Detail Geimpft -->
-    <string name="certificate_reason_vaccinated">"Vaccination"</string>
+	<!-- Wallet: Zertifikat Detail Geimpft -->
+	<string name="certificate_reason_vaccinated">"Vaccination"</string>
 
-    <!-- Wallet: Zertifikat Detail Genesen -->
-    <string name="certificate_reason_recovered">"Recovered"</string>
+	<!-- Wallet: Zertifikat Detail Genesen -->
+	<string name="certificate_reason_recovered">"Recovered"</string>
 
-    <!-- Wallet: Zertifikat Detail Getestet -->
-    <string name="certificate_reason_tested">"Test"</string>
+	<!-- Wallet: Zertifikat Detail Getestet -->
+	<string name="certificate_reason_tested">"Test"</string>
 
-    <!-- Header im Onboardingscreen "Vorteile, Aufbewahren" -->
-    <string name="wallet_onboarding_store_header">"Advantages"</string>
+	<!-- Header im Onboardingscreen "Vorteile, Aufbewahren" -->
+	<string name="wallet_onboarding_store_header">"Advantages"</string>
 
-    <!-- Titel im Onboardingscreen "Vorteile, Aufbewahren" -->
-    <string name="wallet_onboarding_store_title">"Store COVID certificates digitally"</string>
+	<!-- Titel im Onboardingscreen "Vorteile, Aufbewahren" -->
+	<string name="wallet_onboarding_store_title">"Store COVID certificates digitally"</string>
 
-    <!-- Text1 im Onboardingscreen "Vorteile, Aufbewahren" -->
-    <string name="wallet_onboarding_store_text1">"COVID certificates can be simply added to the app and stored digitally. "</string>
+	<!-- Text1 im Onboardingscreen "Vorteile, Aufbewahren" -->
+	<string name="wallet_onboarding_store_text1">"COVID certificates can be simply added to the app and stored digitally. "</string>
 
-    <!-- Text2 im Onboardingscreen "Vorteile, Aufbewahren" -->
-    <string name="wallet_onboarding_store_text2">"The app checks the validity of certificates in Switzerland. This way, you can be sure that your certificates are valid."</string>
+	<!-- Text2 im Onboardingscreen "Vorteile, Aufbewahren" -->
+	<string name="wallet_onboarding_store_text2">"The app checks the validity of certificates in Switzerland. This way, you can be sure that your certificates are valid."</string>
 
-    <!-- Header im Onboarding-Screen "Vorteile, Vorweisen" -->
-    <string name="wallet_onboarding_show_header">"Advantages"</string>
+	<!-- Header im Onboarding-Screen "Vorteile, Vorweisen" -->
+	<string name="wallet_onboarding_show_header">"Advantages"</string>
 
-    <!-- Accessibility: Information -->
-    <string name="accessibility_info_button">"Publication details"</string>
+	<!-- Accessibility: Information -->
+	<string name="accessibility_info_button">"Publication details"</string>
 
-    <!-- Accessibility: FAQ Button Titel -->
-    <string name="accessibility_faq_button">"FAQs"</string>
+	<!-- Accessibility: FAQ Button Titel -->
+	<string name="accessibility_faq_button">"FAQs"</string>
 
-    <!-- Accessibility: Button zur Liste der Zertifikate -->
-    <string name="accessibility_list_button">"List of certificates"</string>
+	<!-- Accessibility: Button zur Liste der Zertifikate -->
+	<string name="accessibility_list_button">"List of certificates"</string>
 
-    <!-- Accessibility: Zertifikate hinzufügen -->
-    <string name="accessibility_add_button">"Add a certificate"</string>
+	<!-- Accessibility: Zertifikate hinzufügen -->
+	<string name="accessibility_add_button">"Add a certificate"</string>
 
-    <!-- Accessibility: Schliessen Button -->
-    <string name="accessibility_close_button">"Close"</string>
+	<!-- Accessibility: Schliessen Button -->
+	<string name="accessibility_close_button">"Close"</string>
 
-    <!-- Accessibility: Taschenlampe anschalten Button -->
-    <string name="accessibility_lamp_on_button">"Turn on torch"</string>
+	<!-- Accessibility: Taschenlampe anschalten Button -->
+	<string name="accessibility_lamp_on_button">"Turn on torch"</string>
 
-    <!-- Accessibility: Lampe abschalten -->
-    <string name="accessibility_lamp_off_button">"Turn off torch"</string>
+	<!-- Accessibility: Lampe abschalten -->
+	<string name="accessibility_lamp_off_button">"Turn off torch"</string>
 
-    <!-- Titel des Impressum-Screens -->
-    <string name="impressum_title">"Publication details"</string>
+	<!-- Titel des Impressum-Screens -->
+	<string name="impressum_title">"Publication details"</string>
 
-    <!-- Unbekannter Fehler -->
-    <string name="unknown_error">"An unknown error has occurred"</string>
+	<!-- Unbekannter Fehler -->
+	<string name="unknown_error">"An unknown error has occurred"</string>
 
-    <!-- Verifier: Die Gültigkeit des Zertifikat ist abgelaufen -->
-    <string name="verifier_verifiy_error_expired">"Does not meet Switzerland's validity criteria.
+	<!-- Verifier: Die Gültigkeit des Zertifikat ist abgelaufen -->
+	<string name="verifier_verifiy_error_expired">"Does not meet Switzerland's validity criteria.
 
 The certificate is no longer valid."</string>
 
-    <!-- Verifier: Zertifikat ist erst gültig ab {DATE} -->
-    <string name="verifier_verifiy_error_notyetvalid">"Does not meet Switzerland's validity criteria.
+	<!-- Verifier: Zertifikat ist erst gültig ab {DATE} -->
+	<string name="verifier_verifiy_error_notyetvalid">"Does not meet Switzerland's validity criteria.
 
 The certificate is not yet valid"</string>
 
-    <!-- Verifier: Ein Netzwerkfehler ist aufgetreten. -->
-    <string name="verifier_retry_network_error">"A network error has occurred"</string>
+	<!-- Verifier: Ein Netzwerkfehler ist aufgetreten. -->
+	<string name="verifier_retry_network_error">"A network error has occurred"</string>
 
-    <!-- Verifier: Das Gerät befindet sich im Flugmodus. -->
-    <string name="verifier_retry_flightmode_error">"Your device is in flight mode"</string>
+	<!-- Verifier: Das Gerät befindet sich im Flugmodus. -->
+	<string name="verifier_retry_flightmode_error">"Your device is in flight mode"</string>
 
-    <!-- Wallet: Zertifikat gültig ab: {DATE} -->
-    <string name="wallet_error_valid_from">"Valid in Switzerland from:
+	<!-- Wallet: Zertifikat gültig ab: {DATE} -->
+	<string name="wallet_error_valid_from">"Valid in Switzerland from:
 {DATE}"</string>
 
-    <!-- Wallet: Fehler wenn Zertifikat nicht den CH-Gültigkeitskriterien entspricht -->
-    <string name="wallet_error_national_rules">"Does not meet the validity criteria for Switzerland"</string>
+	<!-- Wallet: Fehler wenn Zertifikat nicht den CH-Gültigkeitskriterien entspricht -->
+	<string name="wallet_error_national_rules">"Does not meet the validity criteria for Switzerland"</string>
 
-    <!-- Wallet: Gültigkeit des Zertifikats abgelaufen -->
-    <string name="wallet_error_expired">"Period of validity for Switzerland exceeded"</string>
+	<!-- Wallet: Gültigkeit des Zertifikats abgelaufen -->
+	<string name="wallet_error_expired">"Period of validity for Switzerland exceeded"</string>
 
-    <!-- Wallet: Zertifikat wurde widerrufen -->
-    <string name="wallet_error_revocation">"Certificate has been 
+	<!-- Wallet: Zertifikat wurde widerrufen -->
+	<string name="wallet_error_revocation">"Certificate has been
 revoked"</string>
 
-    <!-- Wallet: Zertifikat mit ungültiger Signatur -->
-    <string name="wallet_error_invalid_signature">"Certificate with 
+	<!-- Wallet: Zertifikat mit ungültiger Signatur -->
+	<string name="wallet_error_invalid_signature">"Certificate with
 invalid signature"</string>
 
-    <!-- Wallet: ungültiger Signatur (gleiche Worte wie wallet_error_invalid_signature) -->
-    <string name="wallet_error_invalid_signature_bold">"invalid signature"</string>
+	<!-- Wallet: ungültiger Signatur (gleiche Worte wie wallet_error_invalid_signature) -->
+	<string name="wallet_error_invalid_signature_bold">"invalid signature"</string>
 
-    <!-- Wallet: widerrufen (gleiches Wort wie bei wallet_error_revocation) -->
-    <string name="wallet_error_revocation_bold">"revoked"</string>
+	<!-- Wallet: widerrufen (gleiches Wort wie bei wallet_error_revocation) -->
+	<string name="wallet_error_revocation_bold">"revoked"</string>
 
-    <!-- Meldung wenn erneute ein Zertifikat gescannt wurde, welches bereits in der App ist -->
-    <string name="wallet_certificate_already_exists">"This certificate is already saved in the app"</string>
+	<!-- Meldung wenn erneute ein Zertifikat gescannt wurde, welches bereits in der App ist -->
+	<string name="wallet_certificate_already_exists">"This certificate is already saved in the app"</string>
 
-    <!-- Titel Gültigkeit im Zertifikatsdetail -->
-    <string name="wallet_certificate_validity">"Validity in 
+	<!-- Titel Gültigkeit im Zertifikatsdetail -->
+	<string name="wallet_certificate_validity">"Validity in
 Switzerland"</string>
 
-    <!-- "Bis" Label im Zertifikats-Detail -->
-    <string name="wallet_certificate_valid_until">"until"</string>
+	<!-- "Bis" Label im Zertifikats-Detail -->
+	<string name="wallet_certificate_valid_until">"until"</string>
 
-    <!-- Message im Zertifikatsdetail während Überprüfung -->
-    <string name="wallet_certificate_verifying">"The certificate is being verified"</string>
+	<!-- Message im Zertifikatsdetail während Überprüfung -->
+	<string name="wallet_certificate_verifying">"The certificate is being verified"</string>
 
-    <!-- Message nach erfolgreicher Prüfung im Zertifikatdetail -->
-    <string name="wallet_certificate_verify_success">"Verification successful"</string>
+	<!-- Message nach erfolgreicher Prüfung im Zertifikatdetail -->
+	<string name="wallet_certificate_verify_success">"Verification successful"</string>
 
-    <!-- Accessibility: Info Box Butto -->
-    <string name="accessibility_info_box">"Information"</string>
+	<!-- Accessibility: Info Box Butto -->
+	<string name="accessibility_info_box">"Information"</string>
 
-    <!-- Button Schliessen -->
-    <string name="close_button">"Close"</string>
-    <string name="wallet_certificate_impfdosis_title">"Dose"</string>
-    <string name="target_disease_name">"COVID-19"</string>
-    <string name="wallet_certificate_target_disease_title">"Disease or agent targeted"</string>
-    <string name="wallet_certificate_impfstoff_product_name_title">"Product"</string>
-    <string name="wallet_certificate_impfstoff_holder">"Manufacturer"</string>
-    <string name="wallet_certificate_vaccination_date_title">"Date of vaccination"</string>
-    <string name="wallet_certificate_vaccination_country_title">"Country of vaccination"</string>
-    <string name="wallet_certificate_vaccination_issuer_title">"Issuer"</string>
-    <string name="covid_certificate_recovery_title">"Recovery"</string>
-    <string name="wallet_certificate_recovery_first_positiv_result">"Date of first positive test result"</string>
-    <string name="wallet_certificate_recovery_from">"Valid from"</string>
-    <string name="wallet_certificate_recovery_until">"Valid until"</string>
-    <string name="wallet_certificate_test_land">"Country of test"</string>
-    <string name="covid_certificate_test_title">"Test"</string>
-    <string name="wallet_certificate_test_result_title">"Result"</string>
-    <string name="wallet_certificate_test_result_negativ">"Not detected (Negative)"</string>
-    <string name="wallet_certificate_test_result_positiv">"Detected (Positive)"</string>
-    <string name="wallet_certificate_test_type">"Type"</string>
-    <string name="wallet_certificate_test_name">"Name"</string>
-    <string name="wallet_certificate_test_holder">"Manufacturer"</string>
-    <string name="wallet_certificate_test_sample_date_title">"Date of sample collection"</string>
-    <string name="wallet_certificate_test_result_date_title">"Result date"</string>
+	<!-- Button Schliessen -->
+	<string name="close_button">"Close"</string>
+	<string name="wallet_certificate_impfdosis_title">"Dose"</string>
+	<string name="target_disease_name">"COVID-19"</string>
+	<string name="wallet_certificate_target_disease_title">"Disease or agent targeted"</string>
+	<string name="wallet_certificate_impfstoff_product_name_title">"Product"</string>
+	<string name="wallet_certificate_impfstoff_holder">"Manufacturer"</string>
+	<string name="wallet_certificate_vaccination_date_title">"Date of vaccination"</string>
+	<string name="wallet_certificate_vaccination_country_title">"Country of vaccination"</string>
+	<string name="wallet_certificate_vaccination_issuer_title">"Issuer"</string>
+	<string name="covid_certificate_recovery_title">"Recovery"</string>
+	<string name="wallet_certificate_recovery_first_positiv_result">"Date of first positive test result"</string>
+	<string name="wallet_certificate_recovery_from">"Valid from"</string>
+	<string name="wallet_certificate_recovery_until">"Valid until"</string>
+	<string name="wallet_certificate_test_land">"Country of test"</string>
+	<string name="covid_certificate_test_title">"Test"</string>
+	<string name="wallet_certificate_test_result_title">"Result"</string>
+	<string name="wallet_certificate_test_result_negativ">"Not detected (Negative)"</string>
+	<string name="wallet_certificate_test_result_positiv">"Detected (Positive)"</string>
+	<string name="wallet_certificate_test_type">"Type"</string>
+	<string name="wallet_certificate_test_name">"Name"</string>
+	<string name="wallet_certificate_test_holder">"Manufacturer"</string>
+	<string name="wallet_certificate_test_sample_date_title">"Date of sample collection"</string>
+	<string name="wallet_certificate_test_result_date_title">"Result date"</string>
 
-    <!-- Header im "So funktionierts" Screen der Verifier-App -->
-    <string name="verifier_support_header">"How it works"</string>
+	<!-- Header im "So funktionierts" Screen der Verifier-App -->
+	<string name="verifier_support_header">"How it works"</string>
 
-    <!-- Text im Bestätigungs-Dialog beim Zertifikat löschen -->
-    <string name="wallet_certificate_delete_confirm_text">"Are you sure you want to delete the certificate?"</string>
+	<!-- Text im Bestätigungs-Dialog beim Zertifikat löschen -->
+	<string name="wallet_certificate_delete_confirm_text">"Are you sure you want to delete the certificate?"</string>
 
-    <!-- Titel eines Abbrechen-Buttons -->
-    <string name="cancel_button">"Cancel"</string>
+	<!-- Titel eines Abbrechen-Buttons -->
+	<string name="cancel_button">"Cancel"</string>
 
-    <!-- Wallet: Titel bei Impfungen -->
-    <string name="covid_certificate_vaccination_title">"Vaccination"</string>
+	<!-- Wallet: Titel bei Impfungen -->
+	<string name="covid_certificate_vaccination_title">"Vaccination"</string>
 
-    <!-- Wallet: Apple App Store URL -->
-    <string name="wallet_apple_app_store_url">"http://itunes.apple.com/app/id1565917320"</string>
+	<!-- Wallet: Apple App Store URL -->
+	<string name="wallet_apple_app_store_url">"http://itunes.apple.com/app/id1565917320"</string>
 
-    <!-- Verifier: Apple App Store URL -->
-    <string name="verifier_apple_app_store_url">"http://itunes.apple.com/app/id1565917510"</string>
+	<!-- Verifier: Apple App Store URL -->
+	<string name="verifier_apple_app_store_url">"http://itunes.apple.com/app/id1565917510"</string>
 
-    <!-- Wallet: Abkürzung "UVCI" (Unique Vaccination Certificate Identifier) -->
-    <string name="wallet_certificate_identifier">"UVCI"</string>
+	<!-- Wallet: Abkürzung "UVCI" (Unique Vaccination Certificate Identifier) -->
+	<string name="wallet_certificate_identifier">"UVCI"</string>
 
-    <!-- Wallet: Zertifikat erstellt am {DATE} -->
-    <string name="wallet_certificate_date">"Certificate generated on 
+	<!-- Wallet: Zertifikat erstellt am {DATE} -->
+	<string name="wallet_certificate_date">"Certificate generated on
 {DATE}"</string>
 
-    <!-- Wallet: Detail Art des Impfstoffs -->
-    <string name="wallet_certificate_vaccine_prophylaxis">"Vaccine type"</string>
+	<!-- Wallet: Detail Art des Impfstoffs -->
+	<string name="wallet_certificate_vaccine_prophylaxis">"Vaccine type"</string>
 
-    <!-- Wallet: Test Detail Test durchgeführt durch -->
-    <string name="wallet_certificate_test_done_by">"Test centre"</string>
+	<!-- Wallet: Test Detail Test durchgeführt durch -->
+	<string name="wallet_certificate_test_done_by">"Test centre"</string>
 
-    <!-- iOS: Erklärung bei Kamera  -->
-    <string name="NSCameraUsageDescription">"The app needs access to your camera to be able to scan the QR code."</string>
+	<!-- iOS: Erklärung bei Kamera  -->
+	<string name="NSCameraUsageDescription">"The app needs access to your camera to be able to scan the QR code."</string>
 
-    <!-- Titel 1 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_title">"How COVID certificates are checked"</string>
+	<!-- Titel 1 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_title">"How COVID certificates are checked"</string>
 
-    <!-- Text 1 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_subtitle">"The COVID Certificate Check app can be used to scan the QR codes on COVID certificates and check the certificates for authenticity and validity."</string>
+	<!-- Text 1 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_subtitle">"The COVID Certificate Check app can be used to scan the QR codes on COVID certificates and check the certificates for authenticity and validity."</string>
 
-    <!-- Frage 1 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_question_1">"How can COVID certificates be checked?"</string>
+	<!-- Frage 1 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_question_1">"How can COVID certificates be checked?"</string>
 
-    <!-- Antwort 1 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_answer_1">"To check a COVID certificate, use the dedicated COVID Certificate Check app to scan the QR code on the paper certificate or in the COVID Certificate app presented."</string>
+	<!-- Antwort 1 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_answer_1">"To check a COVID certificate, use the dedicated COVID Certificate Check app to scan the QR code on the paper certificate or in the COVID Certificate app presented."</string>
 
-    <!-- Frage 2 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_question_2">"What exactly is checked?"</string>
+	<!-- Frage 2 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_question_2">"What exactly is checked?"</string>
 
-    <!-- Antwort 2 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_answer_2">"Three aspects are checked when scanning:
+	<!-- Antwort 2 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_answer_2">"Three aspects are checked when scanning:
 – Does the certificate contain a valid electronic signature?
 – Is the certificate unrevoked?
 – Does the certificate meet Switzerland's validity criteria?
 
 If the answer to all three questions is affirmative, the COVID certificate is shown as valid."</string>
 
-    <!-- Frage 3 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_question_3">"Which identification documents are valid? Why do personal details have to be checked?"</string>
+	<!-- Frage 3 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_question_3">"Which identification documents are valid? Why do personal details have to be checked?"</string>
 
-    <!-- Antwort 3 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_answer_3">"Aside from passports or ID cards, other photo identification documents that prove the identity of the person in question (e.g. driving licence) are also accepted. Although the COVID certificate is forgery-proof, the only way to ensure that the certificate shown was issued to the person presenting it is to check the personal details."</string>
+	<!-- Antwort 3 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_answer_3">"Aside from passports or ID cards, other photo identification documents that prove the identity of the person in question (e.g. driving licence) are also accepted. Although the COVID certificate is forgery-proof, the only way to ensure that the certificate shown was issued to the person presenting it is to check the personal details."</string>
 
-    <!-- Frage 4 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_question_4">"Can foreign certificates also be checked?"</string>
+	<!-- Frage 4 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_question_4">"Can foreign certificates also be checked?"</string>
 
-    <!-- Antwort 4 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_answer_4">"Yes, COVID certificates that are compatible with the EU digital COVID certificate can be checked according to Switzerland's validity criteria using the COVID Certificate check app."</string>
+	<!-- Antwort 4 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_answer_4">"Yes, COVID certificates that are compatible with the EU digital COVID certificate can be checked according to Switzerland's validity criteria using the COVID Certificate check app."</string>
 
-    <!-- Frage 5 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_question_5">"What data do I see during the verification process?"</string>
+	<!-- Frage 5 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_question_5">"What data do I see during the verification process?"</string>
 
-    <!-- Antwort 5 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_answer_5">"During the verification process, you see only the certificate holder's name and date of birth, and whether the COVID certificate is valid."</string>
+	<!-- Antwort 5 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_answer_5">"During the verification process, you see only the certificate holder's name and date of birth, and whether the COVID certificate is valid."</string>
 
-    <!-- Frage 6 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_question_6">"Is any data stored in the COVID Certificate Check app or in a central system during the verification process?"</string>
+	<!-- Frage 6 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_question_6">"Is any data stored in the COVID Certificate Check app or in a central system during the verification process?"</string>
 
-    <!-- Antwort 6 im FAQ der Verifier App -->
-    <string name="verifier_faq_works_answer_6">"No, no data is stored during the verification process, be it in the COVID Certificate Check app or in a central system. Therefore, it is not possible to trace which COVID certificate was checked by whom, when and where."</string>
+	<!-- Antwort 6 im FAQ der Verifier App -->
+	<string name="verifier_faq_works_answer_6">"No, no data is stored during the verification process, be it in the COVID Certificate Check app or in a central system. Therefore, it is not possible to trace which COVID certificate was checked by whom, when and where."</string>
 
-    <!-- iOS Button zum Einstellungen öffnen -->
-    <string name="ios_settings_open">"Settings"</string>
+	<!-- iOS Button zum Einstellungen öffnen -->
+	<string name="ios_settings_open">"Settings"</string>
 
-    <!-- Wallet: Onboarding externer Link zu Datenschutz -->
-    <string name="wallet_onboarding_external_privacy_button">"Privacy policy &amp; Terms of use"</string>
+	<!-- Wallet: Onboarding externer Link zu Datenschutz -->
+	<string name="wallet_onboarding_external_privacy_button">"Privacy policy &amp; Terms of use"</string>
 
-    <!-- Wallet: Hinweis im Zertifikat Detail -->
-    <string name="wallet_certificate_detail_note">"This certificate is not a travel document. 
+	<!-- Wallet: Hinweis im Zertifikat Detail -->
+	<string name="wallet_certificate_detail_note">"This certificate is not a travel document.
 &lt;br /&gt;&lt;br /&gt;
 The scientific evidence on COVID-19 vaccination, testing and recovery continues to evolve, including with regard to new virus variants of concern. 
 &lt;br /&gt;&lt;br /&gt;
 Please check the restrictions and rules on validity that apply at your destination before you travel. When you’re abroad, the validity of your certificate is calculated on the basis of the rules in the destination country, which may differ from the validity periods in Switzerland as stated in the COVID Certificate app. You’ll find more on this in &lt;a href=\"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/what-should-i-do-if-my-covid-certificate-about-expire-under-swiss-rules-validity\"&gt;the FAQ&lt;/a&gt;."</string>
-    <string name="wallet_terms_privacy_link">"https://www.bit.admin.ch/bit/en/home/documentation/covid-certificate-app.html"</string>
-    <string name="verifier_terms_privacy_link">"https://www.bit.admin.ch/bit/en/home/documentation/covid-certificate-check-app.html"</string>
+	<string name="wallet_terms_privacy_link">"https://www.bit.admin.ch/bit/en/home/documentation/covid-certificate-app.html"</string>
+	<string name="verifier_terms_privacy_link">"https://www.bit.admin.ch/bit/en/home/documentation/covid-certificate-check-app.html"</string>
 
-    <!-- Verifier: Titel in der App (z.B. Impressum) -->
-    <string name="verifier_app_title">"COVID Certificate Check"</string>
-    <string name="wallet_faq_questions_question_1_1">"How do I get a COVID certificate after I have recovered from COVID-19?"</string>
-    <string name="wallet_faq_questions_answer_1_1">"People who have recovered from COVID-19 can apply for the COVID certificate via an online form on the canton's website. The COVID certificate will then be sent by post."</string>
+	<!-- Verifier: Titel in der App (z.B. Impressum) -->
+	<string name="verifier_app_title">"COVID Certificate Check"</string>
+	<string name="wallet_faq_questions_question_1_1">"How do I get a COVID certificate after I have recovered from COVID-19?"</string>
+	<string name="wallet_faq_questions_answer_1_1">"People who have recovered from COVID-19 can apply for the COVID certificate via an online form on the canton's website. The COVID certificate will then be sent by post."</string>
 
-    <!-- Wallet: Homescreen Was wollen sie machen? -->
-    <string name="wallet_homescreen_what_to_do">"Select next step"</string>
+	<!-- Wallet: Homescreen Was wollen sie machen? -->
+	<string name="wallet_homescreen_what_to_do">"Select next step"</string>
 
-    <!-- Wallet: Homescreen Titel Zertifikat hinzufügen -->
-    <string name="wallet_homescreen_add_title">"Add certificate"</string>
+	<!-- Wallet: Homescreen Titel Zertifikat hinzufügen -->
+	<string name="wallet_homescreen_add_title">"Add certificate"</string>
 
-    <!-- Wallet: Homescreen Zertifikat Description Text -->
-    <string name="wallet_homescreen_add_certificate_description">"You have a COVID certificate in paper form or as a PDF and would like to add it to the app."</string>
+	<!-- Wallet: Homescreen Zertifikat Description Text -->
+	<string name="wallet_homescreen_add_certificate_description">"You have a COVID certificate in paper form or as a PDF and would like to add it to the app."</string>
 
-    <!-- Wallet: Homescreen Transfer-Code erstellen -->
-    <string name="wallet_homescreen_add_transfer_code">"Generate transfer code"</string>
+	<!-- Wallet: Homescreen Transfer-Code erstellen -->
+	<string name="wallet_homescreen_add_transfer_code">"Generate transfer code"</string>
 
-    <!-- Wallet: Transfer Codes Titel -->
-    <string name="wallet_transfer_code_onboarding_title">"Transfer codes"</string>
+	<!-- Wallet: Transfer Codes Titel -->
+	<string name="wallet_transfer_code_onboarding_title">"Transfer codes"</string>
 
-    <!-- Wallet: Transfer Code Text -->
-    <string name="wallet_transfer_code_onboarding_text">"You can use transfer codes e.g. for COVID tests. Your COVID certificate will then be delivered straight to the app."</string>
+	<!-- Wallet: Transfer Code Text -->
+	<string name="wallet_transfer_code_onboarding_text">"You can use transfer codes e.g. for COVID tests. Your COVID certificate will then be delivered straight to the app."</string>
 
-    <!-- Wallet: Transfer Code Onboarding Button -->
-    <string name="wallet_transfer_code_onboarding_button">"Generate code"</string>
+	<!-- Wallet: Transfer Code Onboarding Button -->
+	<string name="wallet_transfer_code_onboarding_button">"Generate code"</string>
 
-    <!-- Wallet: Transfer Code Onboarding So funktioniert's -->
-    <string name="wallet_transfer_code_onboarding_howto">"This is how it works"</string>
+	<!-- Wallet: Transfer Code Onboarding So funktioniert's -->
+	<string name="wallet_transfer_code_onboarding_howto">"This is how it works"</string>
 
-    <!-- prüfen -->
-    <!-- Wallet: Transfer Code: FAQ Titel -->
-    <string name="wallet_transfer_code_faq_questions_title">"Receive COVID certificates directly in the app"</string>
+	<!-- prüfen -->
+	<!-- Wallet: Transfer Code: FAQ Titel -->
+	<string name="wallet_transfer_code_faq_questions_title">"Receive COVID certificates directly in the app"</string>
 
-    <!-- Wallet: Transfer Code FAQ Text -->
-    <string name="wallet_transfer_code_faq_questions_subtitle">"The transfer codes allow COVID certificates to be transmitted quickly and securely. In this way, you receive your certificate (e.g. after a test) directly in the application."</string>
+	<!-- Wallet: Transfer Code FAQ Text -->
+	<string name="wallet_transfer_code_faq_questions_subtitle">"The transfer codes allow COVID certificates to be transmitted quickly and securely. In this way, you receive your certificate (e.g. after a test) directly in the application."</string>
 
-    <!-- Wallet: Transfer Code FAQ Frage 1 -->
-    <string name="wallet_transfer_code_faq_questions_question_1">"Who offers the transmission of the COVID certificate by transfer code?"</string>
+	<!-- Wallet: Transfer Code FAQ Frage 1 -->
+	<string name="wallet_transfer_code_faq_questions_question_1">"Who offers the transmission of the COVID certificate by transfer code?"</string>
 
-    <!-- Wallet: Transfer Code FAQ Frage 2 -->
-    <string name="wallet_transfer_code_faq_questions_question_2">"Can the transfer codes also be used for the transmission of vaccination certificates?"</string>
+	<!-- Wallet: Transfer Code FAQ Frage 2 -->
+	<string name="wallet_transfer_code_faq_questions_question_2">"Can the transfer codes also be used for the transmission of vaccination certificates?"</string>
 
-    <!-- Wallet: Transfer Code FAQ Frage 3 -->
-    <string name="wallet_transfer_code_faq_questions_question_3">"How does the transmission of the certificate by transfer code work?"</string>
+	<!-- Wallet: Transfer Code FAQ Frage 3 -->
+	<string name="wallet_transfer_code_faq_questions_question_3">"How does the transmission of the certificate by transfer code work?"</string>
 
-    <!-- Wallet: Transfer Code FAQ Frage 4 -->
-    <string name="wallet_transfer_code_faq_questions_question_4">"Can I use the same transfer code more than once?"</string>
+	<!-- Wallet: Transfer Code FAQ Frage 4 -->
+	<string name="wallet_transfer_code_faq_questions_question_4">"Can I use the same transfer code more than once?"</string>
 
-    <!-- Wallet: Transfer Code FAQ Antwort 1 -->
-    <string name="wallet_transfer_code_faq_questions_answer_1">"If you perform a COVID test (PCR test or rapid antigen test), the transfer code can be used to quickly transmit the COVID certificate.
+	<!-- Wallet: Transfer Code FAQ Antwort 1 -->
+	<string name="wallet_transfer_code_faq_questions_answer_1">"If you perform a COVID test (PCR test or rapid antigen test), the transfer code can be used to quickly transmit the COVID certificate.
 
 Ask your test centre, pharmacy or doctor if this option is available."</string>
 
-    <!-- Wallet: Transfer Code FAQ Antwort 2 -->
-    <string name="wallet_transfer_code_faq_questions_answer_2">"Currently, the transmission of the certificate by transfer code is reserved for COVID tests. To find out how to obtain a COVID certificate after vaccination, click here:"</string>
+	<!-- Wallet: Transfer Code FAQ Antwort 2 -->
+	<string name="wallet_transfer_code_faq_questions_answer_2">"Currently, the transmission of the certificate by transfer code is reserved for COVID tests. To find out how to obtain a COVID certificate after vaccination, click here:"</string>
 
-    <!-- Wallet: Transfer Code FAQ Antwort 3 -->
-    <string name="wallet_transfer_code_faq_questions_answer_3">"If the test centre offers to transmit the certificate by transfer code, you will be asked for a code at the time of registration or testing.
+	<!-- Wallet: Transfer Code FAQ Antwort 3 -->
+	<string name="wallet_transfer_code_faq_questions_answer_3">"If the test centre offers to transmit the certificate by transfer code, you will be asked for a code at the time of registration or testing.
 
 You can create the transfer code in the \"COVID Certificate\" application: press \"Add\" on the home screen or the \"More\" symbol at the bottom right, then \"Create a transfer code\".
 
 The application will show you a 9-character code, which you can either enter in a form when you register or pass on directly during the test."</string>
 
-    <!-- Wallet: Transfer Code FAQ Antwort 4 -->
-    <string name="wallet_transfer_code_faq_questions_answer_4">"No, a transfer code can only be used once. If you wish to obtain several certificates (e.g. for your relatives), please create a new code for each certificate."</string>
-    <string name="wallet_transfer_code_faq_works_title">"How does the transfer work?"</string>
+	<!-- Wallet: Transfer Code FAQ Antwort 4 -->
+	<string name="wallet_transfer_code_faq_questions_answer_4">"No, a transfer code can only be used once. If you wish to obtain several certificates (e.g. for your relatives), please create a new code for each certificate."</string>
+	<string name="wallet_transfer_code_faq_works_title">"How does the transfer work?"</string>
 
-    <!-- Wallet: Tranfser Code FAQ 2 Frage 1 -->
-    <string name="wallet_transfer_code_faq_works_question_1">"How is my data secured during the transfer?"</string>
+	<!-- Wallet: Tranfser Code FAQ 2 Frage 1 -->
+	<string name="wallet_transfer_code_faq_works_question_1">"How is my data secured during the transfer?"</string>
 
-    <!-- Wallet: Tranfser Code FAQ 2 Frage 2 -->
-    <string name="wallet_transfer_code_faq_works_question_2">"What if my certificate does not arrive in the application?"</string>
+	<!-- Wallet: Tranfser Code FAQ 2 Frage 2 -->
+	<string name="wallet_transfer_code_faq_works_question_2">"What if my certificate does not arrive in the application?"</string>
 
-    <!-- Wallet: Tranfser Code FAQ 2 Frage 3 -->
-    <string name="wallet_transfer_code_faq_works_question_3">"What happens if I test positive?"</string>
+	<!-- Wallet: Tranfser Code FAQ 2 Frage 3 -->
+	<string name="wallet_transfer_code_faq_works_question_3">"What happens if I test positive?"</string>
 
-    <!-- Wallet: Transfer Code FAQ 2 Antwort 1 -->
-    <string name="wallet_transfer_code_faq_works_answer_1">"For the transfer, your COVID certificate is delivered in encrypted form. The transfer code ensures that only your application can receive the certificate. The data is deleted from the server immediately after the transfer."</string>
+	<!-- Wallet: Transfer Code FAQ 2 Antwort 1 -->
+	<string name="wallet_transfer_code_faq_works_answer_1">"For the transfer, your COVID certificate is delivered in encrypted form. The transfer code ensures that only your application can receive the certificate. The data is deleted from the server immediately after the transfer."</string>
 
-    <!-- Wallet: Transfer Code FAQ 2 Antwort 2 -->
-    <string name="wallet_transfer_code_faq_works_answer_2">"Once the certificate has been generated by the laboratory or test centre, it is available for transfer. Make sure that your smartphone is connected to the Internet to receive certificates.
+	<!-- Wallet: Transfer Code FAQ 2 Antwort 2 -->
+	<string name="wallet_transfer_code_faq_works_answer_2">"Once the certificate has been generated by the laboratory or test centre, it is available for transfer. Make sure that your smartphone is connected to the Internet to receive certificates.
 
 If you still do not receive your certificate, contact the place where you performed the test (centre, pharmacy, doctor's practice)."</string>
 
-    <!-- Wallet: Transfer Code FAQ 2 Antwort 3 -->
-    <string name="wallet_transfer_code_faq_works_answer_3">"In case of a positive rapid antigen test, you will not receive a COVID certificate from the laboratory.
+	<!-- Wallet: Transfer Code FAQ 2 Antwort 3 -->
+	<string name="wallet_transfer_code_faq_works_answer_3">"In case of a positive rapid antigen test, you will not receive a COVID certificate from the laboratory.
 
 In case of a positive PCR test, you will receive a COVID certificate for cured persons, valid from the 11th day after the test."</string>
 
-    <!-- Wallet: Transfer Code erstellt Titel -->
-    <string name="wallet_transfer_code_code_created_title">"Your transfer code has been generated"</string>
+	<!-- Wallet: Transfer Code erstellt Titel -->
+	<string name="wallet_transfer_code_code_created_title">"Your transfer code has been generated"</string>
 
-    <!-- Wallet: Transfer-Code -->
-    <string name="wallet_transfer_code_title">"Transfer code"</string>
+	<!-- Wallet: Transfer-Code -->
+	<string name="wallet_transfer_code_title">"Transfer code"</string>
 
-    <!-- Wallet: Transfer Code Erstelltm am {DATE} -->
-    <string name="wallet_transfer_code_createdat">"Generated on {DATE}"</string>
+	<!-- Wallet: Transfer Code Erstelltm am {DATE} -->
+	<string name="wallet_transfer_code_createdat">"Generated on {DATE}"</string>
 
-    <!-- Wallet: Transfer Code Nächste Schritte -->
-    <string name="wallet_transfer_code_next_steps">"Next steps"</string>
+	<!-- Wallet: Transfer Code Nächste Schritte -->
+	<string name="wallet_transfer_code_next_steps">"Next steps"</string>
 
-    <!-- Wallet: Transfer Code Nächste Schritte 1 -->
-    <string name="wallet_transfer_code_next_steps1">"Provide the pharmacy, test centre, or doctor with your code when you get tested."</string>
+	<!-- Wallet: Transfer Code Nächste Schritte 1 -->
+	<string name="wallet_transfer_code_next_steps1">"Provide the pharmacy, test centre, or doctor with your code when you get tested."</string>
 
-    <!-- Wallet: Transfer Code Nächste Schritte 2 -->
-    <string name="wallet_transfer_code_next_steps2">"If you have multiple certificates, e.g. for other family members, generate a new code for each certificate."</string>
+	<!-- Wallet: Transfer Code Nächste Schritte 2 -->
+	<string name="wallet_transfer_code_next_steps2">"If you have multiple certificates, e.g. for other family members, generate a new code for each certificate."</string>
 
-    <!-- Wallet: Transfer Code Fertig Button -->
-    <string name="wallet_transfer_code_done_button">"Done"</string>
+	<!-- Wallet: Transfer Code Fertig Button -->
+	<string name="wallet_transfer_code_done_button">"Done"</string>
 
-    <!-- Wallet: Transfer Code Card Titel -->
-    <string name="wallet_transfer_code_card_title">"Transfer"</string>
+	<!-- Wallet: Transfer Code Card Titel -->
+	<string name="wallet_transfer_code_card_title">"Transfer"</string>
 
-    <!-- Wallet: Transfer Code Staus Warten auf Transfer -->
-    <string name="wallet_transfer_code_state_waiting">"Wait for transfer"</string>
+	<!-- Wallet: Transfer Code Staus Warten auf Transfer -->
+	<string name="wallet_transfer_code_state_waiting">"Wait for transfer"</string>
 
-    <!-- Wallet: Transfer Code Ablauf in 1 Tag -->
-    <string name="wallet_transfer_code_expire_singular">"Only valid for 1 more day"</string>
+	<!-- Wallet: Transfer Code Ablauf in 1 Tag -->
+	<string name="wallet_transfer_code_expire_singular">"Only valid for 1 more day"</string>
 
-    <!-- Wallet: Transfer Code: Läuft ab in {DAYS} Tagen -->
-    <string name="wallet_transfer_code_expire_plural">"Valid for a further {DAYS} days"</string>
+	<!-- Wallet: Transfer Code: Läuft ab in {DAYS} Tagen -->
+	<string name="wallet_transfer_code_expire_plural">"Valid for a further {DAYS} days"</string>
 
-    <!-- Wallet: Transfer Code Status Abgelaufen -->
-    <string name="wallet_transfer_code_state_expired">"Transfer failed"</string>
+	<!-- Wallet: Transfer Code Status Abgelaufen -->
+	<string name="wallet_transfer_code_state_expired">"Transfer failed"</string>
 
-    <!-- Wallet: Transfer Code Alter Code Titel -->
-    <string name="wallet_transfer_code_old_code">"Code expired"</string>
+	<!-- Wallet: Transfer Code Alter Code Titel -->
+	<string name="wallet_transfer_code_old_code">"Code expired"</string>
 
-    <!-- Wallet: Transfer Code State Zuletzt aktualisiert {DATE} -->
-    <string name="wallet_transfer_code_state_updated">"Last updated 
+	<!-- Wallet: Transfer Code State Zuletzt aktualisiert {DATE} -->
+	<string name="wallet_transfer_code_state_updated">"Last updated
 {DATE}"</string>
 
-    <!-- Wallet: Transfer Code Kein Zertifikat mehr -->
-    <string name="wallet_transfer_code_state_no_certificate">"It is no longer possible to receive a certificate using this transfer."</string>
+	<!-- Wallet: Transfer Code Kein Zertifikat mehr -->
+	<string name="wallet_transfer_code_state_no_certificate">"It is no longer possible to receive a certificate using this transfer."</string>
 
-    <!-- Wallet: Fehler Format des Zertifikat ungültig -->
-    <string name="wallet_error_invalid_format">"Certificate format
+	<!-- Wallet: Fehler Format des Zertifikat ungültig -->
+	<string name="wallet_error_invalid_format">"Certificate format
 invalid"</string>
 
-    <!-- Wallet: Fehler Format des Zertifikat ungültig Fett -->
-    <string name="wallet_error_invalid_format_bold">"invalid"</string>
+	<!-- Wallet: Fehler Format des Zertifikat ungültig Fett -->
+	<string name="wallet_error_invalid_format_bold">"invalid"</string>
 
-    <!-- Verifier: Error Ungültiges Format -->
-    <string name="verifier_error_invalid_format">"COVID certificate format invalid."</string>
+	<!-- Verifier: Error Ungültiges Format -->
+	<string name="verifier_error_invalid_format">"COVID certificate format invalid."</string>
 
-    <!-- Homescreen Zertifikat: Offline Modus Text -->
-    <string name="wallet_homescreen_offline">"Offline mode"</string>
+	<!-- Homescreen Zertifikat: Offline Modus Text -->
+	<string name="wallet_homescreen_offline">"Offline mode"</string>
 
-    <!-- Wallet: Detail Offline Text -->
-    <string name="wallet_offline_description">"In order to show the certificate's validity, the app must be online regularly."</string>
+	<!-- Wallet: Detail Offline Text -->
+	<string name="wallet_offline_description">"In order to show the certificate's validity, the app must be online regularly."</string>
 
-    <!-- Wallet: Retry Titel Offline -->
-    <string name="wallet_detail_offline_retry_title">"Verification not possible offline"</string>
+	<!-- Wallet: Retry Titel Offline -->
+	<string name="wallet_detail_offline_retry_title">"Verification not possible offline"</string>
 
-    <!-- Wallet: Detail Netzwerkfehler Titel -->
-    <string name="wallet_detail_network_error_title">"Verification not possible at this time"</string>
+	<!-- Wallet: Detail Netzwerkfehler Titel -->
+	<string name="wallet_detail_network_error_title">"Verification not possible at this time"</string>
 
-    <!-- Wallet: Detail Netzwerkfehler Text -->
-    <string name="wallet_detail_network_error_text">"Please try again later"</string>
+	<!-- Wallet: Detail Netzwerkfehler Text -->
+	<string name="wallet_detail_network_error_text">"Please try again later"</string>
 
-    <!-- Verifier: Titel Fehler wenn kein Internet -->
-    <string name="verifier_offline_error_title">"Offline verification not possible"</string>
+	<!-- Verifier: Titel Fehler wenn kein Internet -->
+	<string name="verifier_offline_error_title">"Offline verification not possible"</string>
 
-    <!-- Verifier: Fehlertext wenn Offline bei Verifikation -->
-    <string name="verifier_offline_error_text">"An internet connection is required to update the checklists"</string>
+	<!-- Verifier: Fehlertext wenn Offline bei Verifikation -->
+	<string name="verifier_offline_error_text">"An internet connection is required to update the checklists"</string>
 
-    <!-- Verifier: Fehler Titel bei Netzwerkfehler -->
-    <string name="verifier_network_error_title">"Verification failed"</string>
+	<!-- Verifier: Fehler Titel bei Netzwerkfehler -->
+	<string name="verifier_network_error_title">"Verification failed"</string>
 
-    <!-- Verifier: Fehler Text bei Netzwerkfehler -->
-    <string name="verifier_network_error_text">"An unexpected error has occurred"</string>
+	<!-- Verifier: Fehler Text bei Netzwerkfehler -->
+	<string name="verifier_network_error_text">"An unexpected error has occurred"</string>
 
-    <!-- Wallet: Text auf Zertifikat auf Homescreen bei Netzwerkfehler -->
-    <string name="wallet_homescreen_network_error">"Validity could not be determined"</string>
+	<!-- Wallet: Text auf Zertifikat auf Homescreen bei Netzwerkfehler -->
+	<string name="wallet_homescreen_network_error">"Validity could not be determined"</string>
 
-    <!-- Wallet: Transfer Code So Funktionierts Text 1 -->
-    <string name="wallet_transfer_code_faq_works_intro_1">"The application regularly checks whether a COVID certificate is available for your transfer code."</string>
+	<!-- Wallet: Transfer Code So Funktionierts Text 1 -->
+	<string name="wallet_transfer_code_faq_works_intro_1">"The application regularly checks whether a COVID certificate is available for your transfer code."</string>
 
-    <!-- Wallet: Transfer Code So Funktionierts Text 2 -->
-    <string name="wallet_transfer_code_faq_works_intro_2">"As soon as the COVID certificate is available, it appears in the application. If you have activated notifications, you will receive a message from the application."</string>
+	<!-- Wallet: Transfer Code So Funktionierts Text 2 -->
+	<string name="wallet_transfer_code_faq_works_intro_2">"As soon as the COVID certificate is available, it appears in the application. If you have activated notifications, you will receive a message from the application."</string>
 
-    <!-- Wallet: Transfer Code So Funktionierts Text 1 -->
-    <string name="wallet_transfer_code_faq_works_intro_3">"The transfer code expires after {TRANSFER_CODE_VALIDITY} days. After this period, the application waits for any further transfers for 72 hours. After that, the transfer code is no longer valid."</string>
+	<!-- Wallet: Transfer Code So Funktionierts Text 1 -->
+	<string name="wallet_transfer_code_faq_works_intro_3">"The transfer code expires after {TRANSFER_CODE_VALIDITY} days. After this period, the application waits for any further transfers for 72 hours. After that, the transfer code is no longer valid."</string>
 
-    <!-- Wallet: Titel im Custom-Popup Notification Permission -->
-    <string name="wallet_notification_permission_title">"Allow notifications"</string>
+	<!-- Wallet: Titel im Custom-Popup Notification Permission -->
+	<string name="wallet_notification_permission_title">"Allow notifications"</string>
 
-    <!-- Wallet: Text im Custom-Popup Notification Permission -->
-    <string name="wallet_notification_permission_text">"The app can notify you when your certificate is ready. Allow the app to send you notifications."</string>
+	<!-- Wallet: Text im Custom-Popup Notification Permission -->
+	<string name="wallet_notification_permission_text">"The app can notify you when your certificate is ready. Allow the app to send you notifications."</string>
 
-    <!-- Wallet: Button im Custom-Popup Notification Permission -->
-    <string name="wallet_notification_permission_button">"Continue"</string>
+	<!-- Wallet: Button im Custom-Popup Notification Permission -->
+	<string name="wallet_notification_permission_button">"Continue"</string>
 
-    <!-- Externe URL im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_external_link">"https://foph-coronavirus.ch/certificate/how-do-i-get-a-covid-certificate-and-how-do-i-use-it/"</string>
+	<!-- Externe URL im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_external_link">"https://foph-coronavirus.ch/certificate/how-do-i-get-a-covid-certificate-and-how-do-i-use-it/"</string>
 
-    <!-- Label der externen URL im "So funktionierts" Screen beim Scannen -->
-    <string name="wallet_scanner_howitworks_external_link_title">"Further information"</string>
+	<!-- Label der externen URL im "So funktionierts" Screen beim Scannen -->
+	<string name="wallet_scanner_howitworks_external_link_title">"Further information"</string>
 
-    <!-- Buttontitel im Screen, wo ein Code erstellt werden kann -->
-    <string name="wallet_transfer_code_create_code_button">"Generate code"</string>
+	<!-- Buttontitel im Screen, wo ein Code erstellt werden kann -->
+	<string name="wallet_transfer_code_create_code_button">"Generate code"</string>
 
-    <!-- Wallet: Transfer Code Ablauf in 1 Tag (fetter Teil) -->
-    <string name="wallet_transfer_code_expire_singular_bold">"1 more day"</string>
+	<!-- Wallet: Transfer Code Ablauf in 1 Tag (fetter Teil) -->
+	<string name="wallet_transfer_code_expire_singular_bold">"1 more day"</string>
 
-    <!-- Wallet: Transfer Code: Läuft in {DAYS} Tagen ab (fetter Teil) -->
-    <string name="wallet_transfer_code_expire_plural_bold">"{DAYS} days"</string>
+	<!-- Wallet: Transfer Code: Läuft in {DAYS} Tagen ab (fetter Teil) -->
+	<string name="wallet_transfer_code_expire_plural_bold">"{DAYS} days"</string>
 
-    <!-- Infotext bei erfolgreicher Prüfung (Blacklist) -->
-    <string name="verifier_verify_success_info_for_blacklist">"Not revoked"</string>
+	<!-- Infotext bei erfolgreicher Prüfung (Blacklist) -->
+	<string name="verifier_verify_success_info_for_blacklist">"Not revoked"</string>
 
-    <!-- Infotext bei erfolgreicher Prüfung (Zertifikat) -->
-    <string name="verifier_verify_success_info_for_certificate_valid">"Signature valid"</string>
+	<!-- Infotext bei erfolgreicher Prüfung (Zertifikat) -->
+	<string name="verifier_verify_success_info_for_certificate_valid">"Signature valid"</string>
 
-    <!-- Teil der Fehlermeldung bei noch nicht/nicht mehr gültigem Zertifikat, der Bold sein sollte (ref. verifier_verifiy_error_expired und _notyetvalid) -->
-    <string name="verifier_verify_error_validity_range_bold">"Does not meet Switzerland's validity criteria."</string>
+	<!-- Teil der Fehlermeldung bei noch nicht/nicht mehr gültigem Zertifikat, der Bold sein sollte (ref. verifier_verifiy_error_expired und _notyetvalid) -->
+	<string name="verifier_verify_error_validity_range_bold">"Does not meet Switzerland's validity criteria."</string>
 
-    <!-- Wallet: Transfer Code Fehler Titel -->
-    <string name="wallet_transfer_code_error_title">"Unable to generate transfer code"</string>
+	<!-- Wallet: Transfer Code Fehler Titel -->
+	<string name="wallet_transfer_code_error_title">"Unable to generate transfer code"</string>
 
-    <!-- Wallet: Erstellen Fehler Titel -->
-    <string name="wallet_transfer_code_no_internet_title">"No Internet connection"</string>
+	<!-- Wallet: Erstellen Fehler Titel -->
+	<string name="wallet_transfer_code_no_internet_title">"No Internet connection"</string>
 
-    <!-- Wallet: Erstellen anderer Fehler Titel -->
-    <string name="wallet_transfer_code_generate_error_title">"An unexpected error has occurred."</string>
+	<!-- Wallet: Erstellen anderer Fehler Titel -->
+	<string name="wallet_transfer_code_generate_error_title">"An unexpected error has occurred."</string>
 
-    <!-- Wallet: Aktualisierung Transfer Code Fehler Titel -->
-    <string name="wallet_transfer_code_update_error_title">"Update not possible at this time"</string>
+	<!-- Wallet: Aktualisierung Transfer Code Fehler Titel -->
+	<string name="wallet_transfer_code_update_error_title">"Update not possible at this time"</string>
 
-    <!-- Wallet: Transfer Code Update Fehler Text -->
-    <string name="wallet_transfer_code_update_no_internet_error_text">"The app must be online to receive the transfer."</string>
+	<!-- Wallet: Transfer Code Update Fehler Text -->
+	<string name="wallet_transfer_code_update_no_internet_error_text">"The app must be online to receive the transfer."</string>
 
-    <!-- Wallet Transfer Code Update Fehler Text -->
-    <string name="wallet_transfer_code_update_general_error_text">"An unexpected error has occurred. Please try again later."</string>
+	<!-- Wallet Transfer Code Update Fehler Text -->
+	<string name="wallet_transfer_code_update_general_error_text">"An unexpected error has occurred. Please try again later."</string>
 
-    <!-- Wallet: Transfer Code Fehlertext bei Generieren -->
-    <string name="wallet_transfer_code_generate_error_text">"Please try again later."</string>
+	<!-- Wallet: Transfer Code Fehlertext bei Generieren -->
+	<string name="wallet_transfer_code_generate_error_text">"Please try again later."</string>
 
-    <!-- Wallet: Transfer Code Fehlertext bei Generieren ohne Internet -->
-    <string name="wallet_transfer_code_generate_no_internet_error_text">"The app must be online to generate a transfer code."</string>
+	<!-- Wallet: Transfer Code Fehlertext bei Generieren ohne Internet -->
+	<string name="wallet_transfer_code_generate_no_internet_error_text">"The app must be online to generate a transfer code."</string>
 
-    <!-- Wallet: Accessibility Name für Refresh Button -->
-    <string name="accessibility_refresh_button">"Update"</string>
-    <string name="wallet_transfer_delete_confirm_text">"Are you sure you want to delete the transfer?"</string>
-    <string name="wallet_notification_transfer_title">"Transfer successful"</string>
-    <string name="wallet_notification_transfer_text">"The COVID certificate has been delivered"</string>
-    <string name="wallet_faq_questions_question_2_1">"How long is the COVID certificate valid?"</string>
-    <string name="wallet_faq_questions_answer_2_1">"Just how long your certificate is valid depends on whether you have been vaccinated, have recovered from COVID or have tested negative. The duration of validity may change in line with the latest scientific findings. The current duration of validity for COVID certificates can be found here:"</string>
-    <string name="wallet_faq_questions_linktext_2_1">"Further information"</string>
-    <string name="wallet_faq_questions_linkurl_2_1">"https://foph-coronavirus.ch/certificate/how-do-i-get-a-covid-certificate-and-how-do-i-use-it/#contents2"</string>
-    <string name="wallet_faq_works_question_3_1">"Can I use the app offline?"</string>
-    <string name="wallet_faq_works_answer_3_1">"You can use the app without an internet connection, so you can still call up your certificates and present them for scanning and verification.
+	<!-- Wallet: Accessibility Name für Refresh Button -->
+	<string name="accessibility_refresh_button">"Update"</string>
+	<string name="wallet_transfer_delete_confirm_text">"Are you sure you want to delete the transfer?"</string>
+	<string name="wallet_notification_transfer_title">"Transfer successful"</string>
+	<string name="wallet_notification_transfer_text">"The COVID certificate has been delivered"</string>
+	<string name="wallet_faq_questions_question_2_1">"How long is the COVID certificate valid?"</string>
+	<string name="wallet_faq_questions_answer_2_1">"Just how long your certificate is valid depends on whether you have been vaccinated, have recovered from COVID or have tested negative. The duration of validity may change in line with the latest scientific findings. The current duration of validity for COVID certificates can be found here:"</string>
+	<string name="wallet_faq_questions_linktext_2_1">"Further information"</string>
+	<string name="wallet_faq_questions_linkurl_2_1">"https://foph-coronavirus.ch/certificate/how-do-i-get-a-covid-certificate-and-how-do-i-use-it/#contents2"</string>
+	<string name="wallet_faq_works_question_3_1">"Can I use the app offline?"</string>
+	<string name="wallet_faq_works_answer_3_1">"You can use the app without an internet connection, so you can still call up your certificates and present them for scanning and verification.
 
 However, in order to show whether your certificate meets Switzerland’s validity criteria and how long it is valid for, the COVID Certificate app has to be online at regular intervals."</string>
-    <string name="verifier_faq_works_question_2_1">"What are the current validity criteria in Switzerland?"</string>
-    <string name="verifier_faq_works_answer_2_1">"The current validity period of COVID certificates can be found here:"</string>
-    <string name="verifier_faq_works_linktext_2_1">"Further information"</string>
-    <string name="verifier_faq_works_linkurl_2_1">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/covid-zertifikat.html#-837133624"</string>
-    <string name="verifier_faq_works_question_7">"Is it possible to verify the certificates offline?"</string>
-    <string name="verifier_faq_works_answer_7">"In principle, COVID certificates can also be verified without an Internet connection. For this purpose, regularly updated checklists are downloaded from a central server. These locally stored checklists must not be older than 48 hours. 
+	<string name="verifier_faq_works_question_2_1">"What are the current validity criteria in Switzerland?"</string>
+	<string name="verifier_faq_works_answer_2_1">"The current validity period of COVID certificates can be found here:"</string>
+	<string name="verifier_faq_works_linktext_2_1">"Further information"</string>
+	<string name="verifier_faq_works_linkurl_2_1">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/covid-zertifikat.html#-837133624"</string>
+	<string name="verifier_faq_works_question_7">"Is it possible to verify the certificates offline?"</string>
+	<string name="verifier_faq_works_answer_7">"In principle, COVID certificates can also be verified without an Internet connection. For this purpose, regularly updated checklists are downloaded from a central server. These locally stored checklists must not be older than 48 hours.
 
 In order to update the checklists, the app must be open and connected to the Internet. Updating occurs immediately and automatically."</string>
 
-    <!-- Button zum QR Code Scannen öffnen -->
-    <string name="wallet_homescreen_qr_code_scannen">"Scan QR code"</string>
+	<!-- Button zum QR Code Scannen öffnen -->
+	<string name="wallet_homescreen_qr_code_scannen">"Scan QR code"</string>
 
-    <!-- Button zum PDF importieren -->
-    <string name="wallet_homescreen_pdf_import">"Import PDF"</string>
+	<!-- Button zum PDF importieren -->
+	<string name="wallet_homescreen_pdf_import">"Import PDF"</string>
 
-    <!-- Wallet: Titel im Transfer Code screen bei deaktiveren Notifications -->
-    <string name="wallet_notification_disabled_titel">"Tip: Activate notifications"</string>
+	<!-- Wallet: Titel im Transfer Code screen bei deaktiveren Notifications -->
+	<string name="wallet_notification_disabled_titel">"Tip: Activate notifications"</string>
 
-    <!-- Wallet: Button im Transfer Code screen bei deaktiveren Notifications der die Einstellungen öffnet -->
-    <string name="wallet_notification_disabled_button">"Activate"</string>
+	<!-- Wallet: Button im Transfer Code screen bei deaktiveren Notifications der die Einstellungen öffnet -->
+	<string name="wallet_notification_disabled_button">"Activate"</string>
 
-    <!-- Titel für einen "Nachweis" (e.g. unvollständige Impfung) -->
-    <string name="wallet_certificate_evidence_title">"Evidence"</string>
+	<!-- Titel für einen "Nachweis" (e.g. unvollständige Impfung) -->
+	<string name="wallet_certificate_evidence_title">"Evidence"</string>
 
-    <!-- Typenbezeichnung für eine unvollständige Impfung -->
-    <string name="wallet_certificate_type_incomplete_vaccine">"Vaccination incomplete"</string>
+	<!-- Typenbezeichnung für eine unvollständige Impfung -->
+	<string name="wallet_certificate_type_incomplete_vaccine">"Vaccination incomplete"</string>
 
-    <!-- Label für das Erstellungsdatum eines Nachweises (mit Platzhalter für Datum und Uhrzeit) -->
-    <string name="wallet_certificate_evidence_creation_date">"Evidence created on
+	<!-- Label für das Erstellungsdatum eines Nachweises (mit Platzhalter für Datum und Uhrzeit) -->
+	<string name="wallet_certificate_evidence_creation_date">"Evidence created on
 {DATE}"</string>
-    <string name="wallet_transfer_code_faq_questions_linktext_2">"Further information"</string>
-    <string name="wallet_transfer_code_faq_questions_linkurl_2">"https://foph-coronavirus.ch/certificate/how-do-i-get-a-covid-certificate-and-how-do-i-use-it/"</string>
+	<string name="wallet_transfer_code_faq_questions_linktext_2">"Further information"</string>
+	<string name="wallet_transfer_code_faq_questions_linkurl_2">"https://foph-coronavirus.ch/certificate/how-do-i-get-a-covid-certificate-and-how-do-i-use-it/"</string>
 
-    <!-- Wallet: Zertifikat Light Button im Zertifikat Detail -->
-    <string name="wallet_certificate_detail_certificate_light_button">"Certificate light"</string>
+	<!-- Wallet: Zertifikat Light Button im Zertifikat Detail -->
+	<string name="wallet_certificate_detail_certificate_light_button">"Certificate light"</string>
 
-    <!-- Wallet: Export Button im Zertifikat Detail -->
-    <string name="wallet_certificate_detail_export_button">"Export"</string>
+	<!-- Wallet: Export Button im Zertifikat Detail -->
+	<string name="wallet_certificate_detail_export_button">"Export"</string>
 
-    <!-- Wallet: Zertifikat Light Title -->
-    <string name="wallet_certificate_light_detail_title">"What is the 'certificate light'?"</string>
+	<!-- Wallet: Zertifikat Light Title -->
+	<string name="wallet_certificate_light_detail_title">"What is the 'certificate light'?"</string>
 
-    <!-- Wallet: Zertifikat Light Summary Titel -->
-    <string name="wallet_certificate_light_detail_summary_title">"Certificate light"</string>
+	<!-- Wallet: Zertifikat Light Summary Titel -->
+	<string name="wallet_certificate_light_detail_summary_title">"Certificate light"</string>
 
-    <!-- Wallet: Zertifikat Light Summary Punkt 1 -->
-    <string name="wallet_certificate_light_detail_summary_1">"Can only be used within Switzerland"</string>
+	<!-- Wallet: Zertifikat Light Summary Punkt 1 -->
+	<string name="wallet_certificate_light_detail_summary_1">"Can only be used within Switzerland"</string>
 
-    <!-- Wallet: Zertifikat Light Summary Punkt 2 -->
-    <string name="wallet_certificate_light_detail_summary_2">"Only contains last name, first name, date of birth and electronic signature"</string>
+	<!-- Wallet: Zertifikat Light Summary Punkt 2 -->
+	<string name="wallet_certificate_light_detail_summary_2">"Only contains last name, first name, date of birth and electronic signature"</string>
 
-    <!-- Wallet: Zertifikat Light Summary Punkt 3 -->
-    <string name="wallet_certificate_light_detail_summary_3">"Only valid for a max of {LIGHT_CERT_VALIDITY_IN_H} hours"</string>
+	<!-- Wallet: Zertifikat Light Summary Punkt 3 -->
+	<string name="wallet_certificate_light_detail_summary_3">"Only valid for a max of {LIGHT_CERT_VALIDITY_IN_H} hours"</string>
 
-    <!-- Wallet: Zertifikat Light Summary Punkt 4 -->
-    <string name="wallet_certificate_light_detail_summary_4">"Your COVID certificate is converted to the 'light' version online."</string>
+	<!-- Wallet: Zertifikat Light Summary Punkt 4 -->
+	<string name="wallet_certificate_light_detail_summary_4">"Your COVID certificate is converted to the 'light' version online."</string>
 
-    <!-- Wallet: Zertifikat Light Summary Punkt 5 -->
-    <string name="wallet_certificate_light_detail_summary_5">"You can deactivate the 'light' version of the certificate and revert to the normal COVID certificate at any time."</string>
+	<!-- Wallet: Zertifikat Light Summary Punkt 5 -->
+	<string name="wallet_certificate_light_detail_summary_5">"You can deactivate the 'light' version of the certificate and revert to the normal COVID certificate at any time."</string>
 
-    <!-- Wallet: Zertifikat Light Aktivieren Button -->
-    <string name="wallet_certificate_light_detail_deactivate_button">"Deactivate"</string>
+	<!-- Wallet: Zertifikat Light Aktivieren Button -->
+	<string name="wallet_certificate_light_detail_deactivate_button">"Deactivate"</string>
 
-    <!-- Wallet: Zertifikat Light Deaktivieren Button -->
-    <string name="wallet_certificate_light_detail_activate_button">"Activate"</string>
+	<!-- Wallet: Zertifikat Light Deaktivieren Button -->
+	<string name="wallet_certificate_light_detail_activate_button">"Activate"</string>
 
-    <!-- Wallet: Zertifikat Light Aktivation Error -->
-    <string name="wallet_certificate_light_detail_activation_error">"'Certificate light' could not be activated"</string>
+	<!-- Wallet: Zertifikat Light Aktivation Error -->
+	<string name="wallet_certificate_light_detail_activation_error">"'Certificate light' could not be activated"</string>
 
-    <!-- Wallet: Zertifikat Light Aktivation Netzwerk Fehler Titel -->
-    <string name="wallet_certificate_light_detail_activation_network_error_text">"The app must be online to activate the 'certificate light'."</string>
+	<!-- Wallet: Zertifikat Light Aktivation Netzwerk Fehler Titel -->
+	<string name="wallet_certificate_light_detail_activation_network_error_text">"The app must be online to activate the 'certificate light'."</string>
 
-    <!-- Info Text bei erfolgreicher Prüfung einers Zertifikate Light -->
-    <string name="verifier_verify_success_certificate_light_info">"Only valid within Switzerland
+	<!-- Info Text bei erfolgreicher Prüfung einers Zertifikate Light -->
+	<string name="verifier_verify_success_certificate_light_info">"Only valid within Switzerland
 and in combination with an identity document"</string>
 
-    <!-- Wallet: Zertifikat Export Title -->
-    <string name="wallet_certificate_export_title">"Export COVID certificate"</string>
+	<!-- Wallet: Zertifikat Export Title -->
+	<string name="wallet_certificate_export_title">"Export COVID certificate"</string>
 
-    <!-- Wallet: Zertifikat Export Erklärung Punkt 1 -->
-    <string name="wallet_certificate_export_summary_1">"A PDF is generated using the data from your COVID certificate that you can print or share."</string>
+	<!-- Wallet: Zertifikat Export Erklärung Punkt 1 -->
+	<string name="wallet_certificate_export_summary_1">"A PDF is generated using the data from your COVID certificate that you can print or share."</string>
 
-    <!-- Wallet: Zertifikat Export Erklärung Punkt 2 -->
-    <string name="wallet_certificate_export_summary_2">"The PDF document is generated online."</string>
+	<!-- Wallet: Zertifikat Export Erklärung Punkt 2 -->
+	<string name="wallet_certificate_export_summary_2">"The PDF document is generated online."</string>
 
-    <!-- Wallet: Zertifikat Export Button -->
-    <string name="wallet_certificate_export_button">"Export"</string>
+	<!-- Wallet: Zertifikat Export Button -->
+	<string name="wallet_certificate_export_button">"Export"</string>
 
-    <!-- Wallet: Zertifikat Export Error Title -->
-    <string name="wallet_certificate_export_detail_error_title">"PDF could not be generated"</string>
+	<!-- Wallet: Zertifikat Export Error Title -->
+	<string name="wallet_certificate_export_detail_error_title">"PDF could not be generated"</string>
 
-    <!-- Wallet: Zertifikat Export Netzwerk Error -->
-    <string name="wallet_certificate_export_detail_network_error_text">"The app must be online to generate a PDF."</string>
-    <string name="accessibility_qr_code">"QR code"</string>
+	<!-- Wallet: Zertifikat Export Netzwerk Error -->
+	<string name="wallet_certificate_export_detail_network_error_text">"The app must be online to generate a PDF."</string>
+	<string name="accessibility_qr_code">"QR code"</string>
 
-    <!-- Wallet: Zertifikat Light Aktivation Netzwerk Fehler Title -->
-    <string name="wallet_certificate_light_detail_activation_network_error_title">"No Internet connection"</string>
+	<!-- Wallet: Zertifikat Light Aktivation Netzwerk Fehler Title -->
+	<string name="wallet_certificate_light_detail_activation_network_error_title">"No Internet connection"</string>
 
-    <!-- Wallet: Zertifikat Light Aktivation General Fehler Text -->
-    <string name="wallet_certificate_light_detail_activation_general_error_text">"Please try again later."</string>
+	<!-- Wallet: Zertifikat Light Aktivation General Fehler Text -->
+	<string name="wallet_certificate_light_detail_activation_general_error_text">"Please try again later."</string>
 
-    <!-- Wallet: Zertifikat Light Aktivation General Fehler Titel -->
-    <string name="wallet_certificate_light_detail_activation_general_error_title">"An unexpected error has occurred."</string>
+	<!-- Wallet: Zertifikat Light Aktivation General Fehler Titel -->
+	<string name="wallet_certificate_light_detail_activation_general_error_title">"An unexpected error has occurred."</string>
 
-    <!-- Wallet: Zertifikat Light Titel -->
-    <string name="wallet_certificate_light_title">"Certificate light"</string>
+	<!-- Wallet: Zertifikat Light Titel -->
+	<string name="wallet_certificate_light_title">"Certificate light"</string>
 
-    <!-- Wallet: Zertifikat Exportieren Detail Title -->
-    <string name="wallet_certificate_export_detail_title">"Export"</string>
+	<!-- Wallet: Zertifikat Exportieren Detail Title -->
+	<string name="wallet_certificate_export_detail_title">"Export"</string>
 
-    <!-- Wallet: Zertifikat Exportieren Summary 1 -->
-    <string name="wallet_certificate_export_detail_summary_1">"A PDF is generated using the data from your COVID certificate that you can print or share."</string>
+	<!-- Wallet: Zertifikat Exportieren Summary 1 -->
+	<string name="wallet_certificate_export_detail_summary_1">"A PDF is generated using the data from your COVID certificate that you can print or share."</string>
 
-    <!-- Wallet: Zertifikat Exportieren Summary 2 -->
-    <string name="wallet_certificate_export_detail_summary_2">"The PDF document is generated online."</string>
+	<!-- Wallet: Zertifikat Exportieren Summary 2 -->
+	<string name="wallet_certificate_export_detail_summary_2">"The PDF document is generated online."</string>
 
-    <!-- Wallet: Zertifikat Exportieren Datail Export Button -->
-    <string name="wallet_certificate_export_detail_export_button">"Export"</string>
+	<!-- Wallet: Zertifikat Exportieren Datail Export Button -->
+	<string name="wallet_certificate_export_detail_export_button">"Export"</string>
 
-    <!-- Wallet: Zertifikat Exportieren Datail Netzwerk Fehler -->
-    <string name="wallet_certificate_export_detail_network_error_title">"No Internet connection"</string>
+	<!-- Wallet: Zertifikat Exportieren Datail Netzwerk Fehler -->
+	<string name="wallet_certificate_export_detail_network_error_title">"No Internet connection"</string>
 
-    <!-- Wallet: Zertifikat Exportieren Datail General Fehler -->
-    <string name="wallet_certificate_export_detail_general_error_title">"An unexpected error has occurred"</string>
+	<!-- Wallet: Zertifikat Exportieren Datail General Fehler -->
+	<string name="wallet_certificate_export_detail_general_error_title">"An unexpected error has occurred"</string>
 
-    <!-- Wallet: Zertifikat Exportieren Datail General Fehler Text -->
-    <string name="wallet_certificate_export_detail_general_error_text">"An unexpected error has occurred. Please try again later."</string>
+	<!-- Wallet: Zertifikat Exportieren Datail General Fehler Text -->
+	<string name="wallet_certificate_export_detail_general_error_text">"An unexpected error has occurred. Please try again later."</string>
 
-    <!-- Wallet: Zertifikat Light Erklärungstext 1 -->
-    <string name="wallet_certificate_light_detail_text_1">"When you activate the 'light' version of the certificate, a new QR code is generated using data from your COVID certificate that does not contain any health-related information."</string>
+	<!-- Wallet: Zertifikat Light Erklärungstext 1 -->
+	<string name="wallet_certificate_light_detail_text_1">"When you activate the 'light' version of the certificate, a new QR code is generated using data from your COVID certificate that does not contain any health-related information."</string>
 
-    <!-- Wallet: Zertifikat Light Erklärungstext 2 -->
-    <string name="wallet_certificate_light_detail_text_2">"While the regular COVID certificate can be used without restriction both in Switzerland and in the EU/EFTA during its period of validity, the 'light' version can only be used in Switzerland. For data protection reasons, the 'light' version has to be reactivated after {LIGHT_CERT_VALIDITY_IN_H} hours. It does not afford any additional rights to the normal COVID certificate."</string>
+	<!-- Wallet: Zertifikat Light Erklärungstext 2 -->
+	<string name="wallet_certificate_light_detail_text_2">"While the regular COVID certificate can be used without restriction both in Switzerland and in the EU/EFTA during its period of validity, the 'light' version can only be used in Switzerland. For data protection reasons, the 'light' version has to be reactivated after {LIGHT_CERT_VALIDITY_IN_H} hours. It does not afford any additional rights to the normal COVID certificate."</string>
 
-    <!-- Wallet: Zertifikat Light Erklärungstext Bold -->
-    <string name="wallet_certificate_light_detail_text_2_bold">"only has to does not"</string>
+	<!-- Wallet: Zertifikat Light Erklärungstext Bold -->
+	<string name="wallet_certificate_light_detail_text_2_bold">"only has to does not"</string>
 
-    <!-- VoiceOver reads this when the expandable box is reduced -->
-    <string name="accessibility_expandable_box_reduced_state">"reduced"</string>
+	<!-- VoiceOver reads this when the expandable box is reduced -->
+	<string name="accessibility_expandable_box_reduced_state">"reduced"</string>
 
-    <!-- VoiceOver reads this when the expandable box is expanded -->
-    <string name="accessibility_expandable_box_expanded_state">"expanded"</string>
+	<!-- VoiceOver reads this when the expandable box is expanded -->
+	<string name="accessibility_expandable_box_expanded_state">"expanded"</string>
 
-    <!-- Header im Update Boarding-Screen -->
-    <string name="wallet_update_boarding_header">"Update"</string>
+	<!-- Header im Update Boarding-Screen -->
+	<string name="wallet_update_boarding_header">"Update"</string>
 
-    <!-- Titel im Zertifikat Light-Screen -->
-    <string name="wallet_update_boarding_certificate_light_title">"Certificate light"</string>
+	<!-- Titel im Zertifikat Light-Screen -->
+	<string name="wallet_update_boarding_certificate_light_title">"Certificate light"</string>
 
-    <!-- Text im Zertifikat Light-Screen -->
-    <string name="wallet_update_boarding_certificate_light_text">"This update allows you to generate a copy of the certificate without health-related data for use in Switzerland. The privacy policy and terms of use have been updated accordingly. These are deemed to have been accepted if you continue to use the app."</string>
+	<!-- Text im Zertifikat Light-Screen -->
+	<string name="wallet_update_boarding_certificate_light_text">"This update allows you to generate a copy of the certificate without health-related data for use in Switzerland. The privacy policy and terms of use have been updated accordingly. These are deemed to have been accepted if you continue to use the app."</string>
 
-    <!-- Header im Update Boarding-Screen -->
-    <string name="verifier_update_boarding_header">"Update"</string>
+	<!-- Header im Update Boarding-Screen -->
+	<string name="verifier_update_boarding_header">"Update"</string>
 
-    <!-- Titel im Zertifikat Light-Screen -->
-    <string name="verifier_update_boarding_certificate_light_title">"Certificate light"</string>
+	<!-- Titel im Zertifikat Light-Screen -->
+	<string name="verifier_update_boarding_certificate_light_title">"Certificate light"</string>
 
-    <!-- Text im Zertifikat Light-Screen -->
-    <string name="verifier_update_boarding_certificate_light_text">"This update allows you to check certificate copies without health-related data in the app. The privacy policy and terms of use have been updated accordingly. These are deemed to have been accepted if you continue to use the app."</string>
+	<!-- Text im Zertifikat Light-Screen -->
+	<string name="verifier_update_boarding_certificate_light_text">"This update allows you to check certificate copies without health-related data in the app. The privacy policy and terms of use have been updated accordingly. These are deemed to have been accepted if you continue to use the app."</string>
 
-    <!-- Verifier: Die Gültigkeit eines Certificate Light ist abgelaufen -->
-    <string name="verifier_certificate_light_error_expired">"Certificate validity 
+	<!-- Verifier: Die Gültigkeit eines Certificate Light ist abgelaufen -->
+	<string name="verifier_certificate_light_error_expired">"Certificate validity
 expired"</string>
 
-    <!-- Wallet: Badge für Light-Zertifikate in Liste Zertifikate -->
-    <string name="wallet_certificate_list_light_certificate_badge">"Light"</string>
-    <string name="wallet_faq_questions_question_6">"What is the 'certificate light'"</string>
+	<!-- Wallet: Badge für Light-Zertifikate in Liste Zertifikate -->
+	<string name="wallet_certificate_list_light_certificate_badge">"Light"</string>
+	<string name="wallet_faq_questions_question_6">"What is the 'certificate light'"</string>
 
-    <!-- there is a placeholder ({LIGHT_CERT_VALIDITY_IN_H}) which describes the number of hours a light certificate is valid. do NOT translate! -->
-    <string name="wallet_faq_questions_answer_6">"The COVID Certificate app offers holders of COVID certificates the possibility of generating a copy of the certificate with minimised data. This 'certificate light' merely shows that the holder has a valid COVID certificate but does not contain any health-related data. 
-
-The alternative to the COVID certificate containing minimised data was developed at the wish of the Federal Data Protection and Information Commissioner (FDPIC) as third parties using apps they have developed themselves could be able to see health-related data such as the vaccine administered or date of vaccination when checking the certificate. The 'certificate light' prevents this.
-
-The 'Certificate light' is only available electronically in the app and is only recognised in Switzerland. For data protection reasons the 'certificate light' is only valid for {LIGHT_CERT_VALIDITY_IN_H} hours and must then be reactivated. If you need to use the normal certificate before the end of the {LIGHT_CERT_VALIDITY_IN_H}-hour period, you can simply deactivate the 'certificate light'."</string>
-    <string name="verifier_faq_works_question_8">"What is the 'certificate light'"</string>
-
-    <!-- there is a placeholder ({LIGHT_CERT_VALIDITY_IN_H}) which describes the number of hours a light certificate is valid. do NOT translate! -->
-    <string name="verifier_faq_works_answer_8">"The COVID Certificate app offers holders of COVID certificates the possibility of generating a copy of the certificate with minimised data. This 'certificate light' merely shows that the holder has a valid COVID certificate but does not contain any health-related data. 
+	<!-- there is a placeholder ({LIGHT_CERT_VALIDITY_IN_H}) which describes the number of hours a light certificate is valid. do NOT translate! -->
+	<string name="wallet_faq_questions_answer_6">"The COVID Certificate app offers holders of COVID certificates the possibility of generating a copy of the certificate with minimised data. This 'certificate light' merely shows that the holder has a valid COVID certificate but does not contain any health-related data. 
 
 The alternative to the COVID certificate containing minimised data was developed at the wish of the Federal Data Protection and Information Commissioner (FDPIC) as third parties using apps they have developed themselves could be able to see health-related data such as the vaccine administered or date of vaccination when checking the certificate. The 'certificate light' prevents this.
 
 The 'Certificate light' is only available electronically in the app and is only recognised in Switzerland. For data protection reasons the 'certificate light' is only valid for {LIGHT_CERT_VALIDITY_IN_H} hours and must then be reactivated. If you need to use the normal certificate before the end of the {LIGHT_CERT_VALIDITY_IN_H}-hour period, you can simply deactivate the 'certificate light'."</string>
-    <string name="verifier_faq_works_question_9">"How can a 'certificate light' be converted back into an EU/EFTA-compliant COVID certificate?"</string>
-    <string name="verifier_faq_works_answer_9">"The holder can deactivate a 'certificate light' any time in their COVID Certificate app. After that their normal COVID certificate is available again."</string>
+	<string name="verifier_faq_works_question_8">"What is the 'certificate light'"</string>
 
-    <!-- Wallet: Light Zertifikat Accessibility Gültigkeits Label {TIMESPAN} wird ersetzt durch zB. 5 Stunden 3 Minuten -->
-    <string name="wallet_accessibility_light_certificate_expiration_timer">"Valid for {TIMESPAN}"</string>
+	<!-- there is a placeholder ({LIGHT_CERT_VALIDITY_IN_H}) which describes the number of hours a light certificate is valid. do NOT translate! -->
+	<string name="verifier_faq_works_answer_8">"The COVID Certificate app offers holders of COVID certificates the possibility of generating a copy of the certificate with minimised data. This 'certificate light' merely shows that the holder has a valid COVID certificate but does not contain any health-related data. 
 
-    <!-- Toast Text wenn ein Transfer Code durch Klicken kopiert wurde -->
-    <string name="wallet_transfer_code_copied">"Transfer code copied"</string>
-    <string name="wallet_faq_works_question_2_1">"What is a transfer code?"</string>
-    <string name="wallet_faq_works_answer_2_1">"The transfer codes allow COVID certificates to be transmitted quickly and securely. In this way, you receive your certificate (e.g. after a test) directly in the application."</string>
-    <string name="wallet_faq_works_question_5_1">"I only have my COVID certificate electronically in the app. How can I get the certificate as a PDF or on paper?"</string>
-    <string name="wallet_faq_works_answer_5_1">"In the detailed view of the electronic COVID certificate in the COVID Certificate app you’ll find the Export function. You can use this to generate, save and print a PDF"</string>
+The alternative to the COVID certificate containing minimised data was developed at the wish of the Federal Data Protection and Information Commissioner (FDPIC) as third parties using apps they have developed themselves could be able to see health-related data such as the vaccine administered or date of vaccination when checking the certificate. The 'certificate light' prevents this.
 
-    <!-- wallet android app google play store deep link -->
-    <string name="wallet_android_app_google_play_store_url">"market://details?id=ch.admin.bag.covidcertificate.wallet"</string>
+The 'Certificate light' is only available electronically in the app and is only recognised in Switzerland. For data protection reasons the 'certificate light' is only valid for {LIGHT_CERT_VALIDITY_IN_H} hours and must then be reactivated. If you need to use the normal certificate before the end of the {LIGHT_CERT_VALIDITY_IN_H}-hour period, you can simply deactivate the 'certificate light'."</string>
+	<string name="verifier_faq_works_question_9">"How can a 'certificate light' be converted back into an EU/EFTA-compliant COVID certificate?"</string>
+	<string name="verifier_faq_works_answer_9">"The holder can deactivate a 'certificate light' any time in their COVID Certificate app. After that their normal COVID certificate is available again."</string>
 
-    <!-- verifer android app google play store deep link -->
-    <string name="verifier_android_app_google_play_store_url">"market://details?id=ch.admin.bag.covidcertificate.verifier"</string>
+	<!-- Wallet: Light Zertifikat Accessibility Gültigkeits Label {TIMESPAN} wird ersetzt durch zB. 5 Stunden 3 Minuten -->
+	<string name="wallet_accessibility_light_certificate_expiration_timer">"Valid for {TIMESPAN}"</string>
 
-    <!-- Wallet: Titel Fehlermeldung wenn Conversion Rate Limit erreicht wurde -->
-    <string name="wallet_certificate_light_rate_limit_title">"24h-limit reached"</string>
+	<!-- Toast Text wenn ein Transfer Code durch Klicken kopiert wurde -->
+	<string name="wallet_transfer_code_copied">"Transfer code copied"</string>
+	<string name="wallet_faq_works_question_2_1">"What is a transfer code?"</string>
+	<string name="wallet_faq_works_answer_2_1">"The transfer codes allow COVID certificates to be transmitted quickly and securely. In this way, you receive your certificate (e.g. after a test) directly in the application."</string>
+	<string name="wallet_faq_works_question_5_1">"I only have my COVID certificate electronically in the app. How can I get the certificate as a PDF or on paper?"</string>
+	<string name="wallet_faq_works_answer_5_1">"In the detailed view of the electronic COVID certificate in the COVID Certificate app you’ll find the Export function. You can use this to generate, save and print a PDF"</string>
 
-    <!-- Wallet: Text Fehlermeldung wenn Conversion Rate Limit erreicht wurde -->
-    <string name="wallet_certificate_light_rate_limit_text">"The 'certificate light' has been activated too often within the last 24 hours."</string>
-    <string name="error_file_import_title">"Import unsuccessful"</string>
-    <string name="error_file_import_text">"The file contains either an invalid QR code or the QR code was not able to be recognised."</string>
+	<!-- wallet android app google play store deep link -->
+	<string name="wallet_android_app_google_play_store_url">"market://details?id=ch.admin.bag.covidcertificate.wallet"</string>
 
-    <!-- Wallet: Transfercode ein unerwartet Fehler ist aufgetreten titel -->
-    <string name="wallet_transfer_code_unexpected_error_title">"Unexpected error"</string>
+	<!-- verifer android app google play store deep link -->
+	<string name="verifier_android_app_google_play_store_url">"market://details?id=ch.admin.bag.covidcertificate.verifier"</string>
 
-    <!-- Wallet: Transfercode ein unerwartet Fehler ist aufgetreten text -->
-    <string name="wallet_transfer_code_unexpected_error_text">"Please contact support"</string>
+	<!-- Wallet: Titel Fehlermeldung wenn Conversion Rate Limit erreicht wurde -->
+	<string name="wallet_certificate_light_rate_limit_title">"24h-limit reached"</string>
 
-    <!-- Wallet: Transfercode ein unerwartet Fehler ist aufgetreten telefon nummer -->
-    <string name="wallet_transfer_code_unexpected_error_phone_number">"+41 58 466 07 99"</string>
-    <string name="error_corrupt_sharedprefs_title">"Decryption error"</string>
-    <string name="error_corrupt_sharedprefs_text">"One of the app's data storage areas could not be decrypted. To continue using the app, the storage area will have to be deleted and recreated. Data will be lost in the process."</string>
+	<!-- Wallet: Text Fehlermeldung wenn Conversion Rate Limit erreicht wurde -->
+	<string name="wallet_certificate_light_rate_limit_text">"The 'certificate light' has been activated too often within the last 24 hours."</string>
+	<string name="error_file_import_title">"Import unsuccessful"</string>
+	<string name="error_file_import_text">"The file contains either an invalid QR code or the QR code was not able to be recognised."</string>
 
-    <!-- Einstellungen: Titel -->
-    <string name="settings_title">"Settings"</string>
+	<!-- Wallet: Transfercode ein unerwartet Fehler ist aufgetreten titel -->
+	<string name="wallet_transfer_code_unexpected_error_title">"Unexpected error"</string>
 
-    <!-- Einstellungen: Titel Sprachauswahl -->
-    <string name="language_title">"Language"</string>
+	<!-- Wallet: Transfercode ein unerwartet Fehler ist aufgetreten text -->
+	<string name="wallet_transfer_code_unexpected_error_text">"Please contact support"</string>
 
-    <!-- Information about the date format (always english) -->
-    <string name="wallet_certificate_detail_date_format_info">"Date format used: dd.mm.yyyy"</string>
-    <string name="wallet_certificate_test_holder_and_name">"Manufacturer and Name"</string>
+	<!-- Wallet: Transfercode ein unerwartet Fehler ist aufgetreten telefon nummer -->
+	<string name="wallet_transfer_code_unexpected_error_phone_number">"+41 58 466 07 99"</string>
+	<string name="error_corrupt_sharedprefs_title">"Decryption error"</string>
+	<string name="error_corrupt_sharedprefs_text">"One of the app's data storage areas could not be decrypted. To continue using the app, the storage area will have to be deleted and recreated. Data will be lost in the process."</string>
 
-    <!-- Wallet: Fehler-Titel falls Uhrzeit falsch eingestellt bei Transfer-Code -->
-    <string name="wallet_transfer_code_time_inconsistency_title">"Time error"</string>
+	<!-- Einstellungen: Titel -->
+	<string name="settings_title">"Settings"</string>
 
-    <!-- Wallet: Transfer-Code Fehler-Text, falls Zeit falsch eingestellt -->
-    <string name="wallet_transfer_code_time_inconsistency_text">"The time must be set correctly for transfer codes to work. Adjust the time and try again."</string>
+	<!-- Einstellungen: Titel Sprachauswahl -->
+	<string name="language_title">"Language"</string>
 
-    <!-- Toast Text wenn ein UVCI durch Klicken kopiert wurde -->
-    <string name="wallet_uvci_copied">"UVCI copied"</string>
+	<!-- Information about the date format (always english) -->
+	<string name="wallet_certificate_detail_date_format_info">"Date format used: dd.mm.yyyy"</string>
+	<string name="wallet_certificate_test_holder_and_name">"Manufacturer and Name"</string>
 
-    <!-- canton name ag -->
-    <string name="vaccination_booking_ag_name">"Aargau"</string>
+	<!-- Wallet: Fehler-Titel falls Uhrzeit falsch eingestellt bei Transfer-Code -->
+	<string name="wallet_transfer_code_time_inconsistency_title">"Time error"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ag -->
-    <string name="vaccination_booking_ag_url">"https://www.ag.ch/coronavirus-impfung"</string>
+	<!-- Wallet: Transfer-Code Fehler-Text, falls Zeit falsch eingestellt -->
+	<string name="wallet_transfer_code_time_inconsistency_text">"The time must be set correctly for transfer codes to work. Adjust the time and try again."</string>
 
-    <!-- canton name ar -->
-    <string name="vaccination_booking_ar_name">"Appenzell Ausserrhoden"</string>
+	<!-- Toast Text wenn ein UVCI durch Klicken kopiert wurde -->
+	<string name="wallet_uvci_copied">"UVCI copied"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ar -->
-    <string name="vaccination_booking_ar_url">"https://www.ar.ch/verwaltung/departement-gesundheit-und-soziales/amt-fuer-gesundheit/informationsseite-coronavirus/coronaimpfung/"</string>
+	<!-- canton name ag -->
+	<string name="vaccination_booking_ag_name">"Aargau"</string>
 
-    <!-- canton name ai -->
-    <string name="vaccination_booking_ai_name">"Appenzell Innerrhoden"</string>
+	<!-- url for booking an appointment for vaccination for canton ag -->
+	<string name="vaccination_booking_ag_url">"https://www.ag.ch/coronavirus-impfung"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ai -->
-    <string name="vaccination_booking_ai_url">"https://www.ai.ch/coronavirus-impfung"</string>
+	<!-- canton name ar -->
+	<string name="vaccination_booking_ar_name">"Appenzell Ausserrhoden"</string>
 
-    <!-- canton name bl -->
-    <string name="vaccination_booking_bl_name">"Basel-Country"</string>
+	<!-- url for booking an appointment for vaccination for canton ar -->
+	<string name="vaccination_booking_ar_url">"https://www.ar.ch/verwaltung/departement-gesundheit-und-soziales/amt-fuer-gesundheit/informationsseite-coronavirus/coronaimpfung/"</string>
 
-    <!-- url for booking an appointment for vaccination for canton bl -->
-    <string name="vaccination_booking_bl_url">"https://www.baselland.ch/politik-und-behorden/direktionen/volkswirtschafts-und-gesundheitsdirektion/amt-fur-gesundheit/medizinische-dienste/kantonsarztlicher-dienst/aktuelles/corona-impfung/englisch-english"</string>
+	<!-- canton name ai -->
+	<string name="vaccination_booking_ai_name">"Appenzell Innerrhoden"</string>
 
-    <!-- canton name bs -->
-    <string name="vaccination_booking_bs_name">"Basel-City"</string>
+	<!-- url for booking an appointment for vaccination for canton ai -->
+	<string name="vaccination_booking_ai_url">"https://www.ai.ch/coronavirus-impfung"</string>
 
-    <!-- url for booking an appointment for vaccination for canton bs -->
-    <string name="vaccination_booking_bs_url">"http://www.coronaimpfzentrumbasel.ch"</string>
+	<!-- canton name bl -->
+	<string name="vaccination_booking_bl_name">"Basel-Country"</string>
 
-    <!-- canton name be -->
-    <string name="vaccination_booking_be_name">"Berne"</string>
+	<!-- url for booking an appointment for vaccination for canton bl -->
+	<string name="vaccination_booking_bl_url">"https://www.baselland.ch/politik-und-behorden/direktionen/volkswirtschafts-und-gesundheitsdirektion/amt-fur-gesundheit/medizinische-dienste/kantonsarztlicher-dienst/aktuelles/corona-impfung/englisch-english"</string>
 
-    <!-- url for booking an appointment for vaccination for canton be -->
-    <string name="vaccination_booking_be_url">"http://www.be.ch/corona-impfung"</string>
+	<!-- canton name bs -->
+	<string name="vaccination_booking_bs_name">"Basel-City"</string>
 
-    <!-- canton name fr -->
-    <string name="vaccination_booking_fr_name">"Fribourg"</string>
+	<!-- url for booking an appointment for vaccination for canton bs -->
+	<string name="vaccination_booking_bs_url">"http://www.coronaimpfzentrumbasel.ch"</string>
 
-    <!-- url for booking an appointment for vaccination for canton fr -->
-    <string name="vaccination_booking_fr_url">"https://www.fr.ch/sante/covid-19/covid-19-vaccination"</string>
+	<!-- canton name be -->
+	<string name="vaccination_booking_be_name">"Berne"</string>
 
-    <!-- canton name ge -->
-    <string name="vaccination_booking_ge_name">"Geneva"</string>
+	<!-- url for booking an appointment for vaccination for canton be -->
+	<string name="vaccination_booking_be_url">"http://www.be.ch/corona-impfung"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ge -->
-    <string name="vaccination_booking_ge_url">"https://www.ge.ch/en/getting-vaccinated-against-covid-19"</string>
+	<!-- canton name fr -->
+	<string name="vaccination_booking_fr_name">"Fribourg"</string>
 
-    <!-- canton name gl -->
-    <string name="vaccination_booking_gl_name">"Glarus"</string>
+	<!-- url for booking an appointment for vaccination for canton fr -->
+	<string name="vaccination_booking_fr_url">"https://www.fr.ch/sante/covid-19/covid-19-vaccination"</string>
 
-    <!-- url for booking an appointment for vaccination for canton gl -->
-    <string name="vaccination_booking_gl_url">"https://www.gl.ch/verwaltung/finanzen-und-gesundheit/gesundheit/coronavirus.html/4817#Impfung"</string>
+	<!-- canton name ge -->
+	<string name="vaccination_booking_ge_name">"Geneva"</string>
 
-    <!-- canton name gr -->
-    <string name="vaccination_booking_gr_name">"Graubünden"</string>
+	<!-- url for booking an appointment for vaccination for canton ge -->
+	<string name="vaccination_booking_ge_url">"https://www.ge.ch/en/getting-vaccinated-against-covid-19"</string>
 
-    <!-- url for booking an appointment for vaccination for canton gr -->
-    <string name="vaccination_booking_gr_url">"https://www.gr.ch/DE/institutionen/verwaltung/djsg/ga/coronavirus/info/impfen/Seiten/impfen.aspx"</string>
+	<!-- canton name gl -->
+	<string name="vaccination_booking_gl_name">"Glarus"</string>
 
-    <!-- canton name ju -->
-    <string name="vaccination_booking_ju_name">"Jura"</string>
+	<!-- url for booking an appointment for vaccination for canton gl -->
+	<string name="vaccination_booking_gl_url">"https://www.gl.ch/verwaltung/finanzen-und-gesundheit/gesundheit/coronavirus.html/4817#Impfung"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ju -->
-    <string name="vaccination_booking_ju_url">"https://www.jura.ch/fr/Autorites/Coronavirus/Vaccination.html"</string>
+	<!-- canton name gr -->
+	<string name="vaccination_booking_gr_name">"Graubünden"</string>
 
-    <!-- canton name lu -->
-    <string name="vaccination_booking_lu_name">"Lucerne"</string>
+	<!-- url for booking an appointment for vaccination for canton gr -->
+	<string name="vaccination_booking_gr_url">"https://www.gr.ch/DE/institutionen/verwaltung/djsg/ga/coronavirus/info/impfen/Seiten/impfen.aspx"</string>
 
-    <!-- url for booking an appointment for vaccination for canton lu -->
-    <string name="vaccination_booking_lu_url">"http://www.lu.ch/covid_impfung"</string>
+	<!-- canton name ju -->
+	<string name="vaccination_booking_ju_name">"Jura"</string>
 
-    <!-- canton name ne -->
-    <string name="vaccination_booking_ne_name">"Neuchâtel"</string>
+	<!-- url for booking an appointment for vaccination for canton ju -->
+	<string name="vaccination_booking_ju_url">"https://www.jura.ch/fr/Autorites/Coronavirus/Vaccination.html"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ne -->
-    <string name="vaccination_booking_ne_url">"https://www.ne.ch/autorites/DFS/SCSP/medecin-cantonal/maladies-vaccinations/covid-19-vaccination/Pages/accueil.aspx"</string>
+	<!-- canton name lu -->
+	<string name="vaccination_booking_lu_name">"Lucerne"</string>
 
-    <!-- canton name nw -->
-    <string name="vaccination_booking_nw_name">"Nidwalden"</string>
+	<!-- url for booking an appointment for vaccination for canton lu -->
+	<string name="vaccination_booking_lu_url">"http://www.lu.ch/covid_impfung"</string>
 
-    <!-- url for booking an appointment for vaccination for canton nw -->
-    <string name="vaccination_booking_nw_url">"https://www.nw.ch/gesundheitsamtdienste/6044#Impfung"</string>
+	<!-- canton name ne -->
+	<string name="vaccination_booking_ne_name">"Neuchâtel"</string>
 
-    <!-- canton name ow -->
-    <string name="vaccination_booking_ow_name">"Obwalden"</string>
+	<!-- url for booking an appointment for vaccination for canton ne -->
+	<string name="vaccination_booking_ne_url">"https://www.ne.ch/autorites/DFS/SCSP/medecin-cantonal/maladies-vaccinations/covid-19-vaccination/Pages/accueil.aspx"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ow -->
-    <string name="vaccination_booking_ow_url">"https://www.ow.ch/dienstleistungen/7129"</string>
+	<!-- canton name nw -->
+	<string name="vaccination_booking_nw_name">"Nidwalden"</string>
 
-    <!-- canton name sg -->
-    <string name="vaccination_booking_sg_name">"St. Gallen"</string>
+	<!-- url for booking an appointment for vaccination for canton nw -->
+	<string name="vaccination_booking_nw_url">"https://www.nw.ch/gesundheitsamtdienste/6044#Impfung"</string>
 
-    <!-- url for booking an appointment for vaccination for canton sg -->
-    <string name="vaccination_booking_sg_url">"https://www.sg.ch/coronavirus/impfen"</string>
+	<!-- canton name ow -->
+	<string name="vaccination_booking_ow_name">"Obwalden"</string>
 
-    <!-- canton name sh -->
-    <string name="vaccination_booking_sh_name">"Schaffhausen"</string>
+	<!-- url for booking an appointment for vaccination for canton ow -->
+	<string name="vaccination_booking_ow_url">"https://www.ow.ch/dienstleistungen/7129"</string>
 
-    <!-- url for booking an appointment for vaccination for canton sh -->
-    <string name="vaccination_booking_sh_url">"https://sh.ch/CMS/Webseite/Kanton-Schaffhausen/Beh-rde/Verwaltung/Departement-des-Innern/Gesundheitsamt-7126057-DE.html"</string>
+	<!-- canton name sg -->
+	<string name="vaccination_booking_sg_name">"St. Gallen"</string>
 
-    <!-- canton name sz -->
-    <string name="vaccination_booking_sz_name">"Schwyz"</string>
+	<!-- url for booking an appointment for vaccination for canton sg -->
+	<string name="vaccination_booking_sg_url">"https://www.sg.ch/coronavirus/impfen"</string>
 
-    <!-- url for booking an appointment for vaccination for canton sz -->
-    <string name="vaccination_booking_sz_url">"https://www.sz.ch/corona-impfen"</string>
+	<!-- canton name sh -->
+	<string name="vaccination_booking_sh_name">"Schaffhausen"</string>
 
-    <!-- canton name so -->
-    <string name="vaccination_booking_so_name">"Solothurn"</string>
+	<!-- url for booking an appointment for vaccination for canton sh -->
+	<string name="vaccination_booking_sh_url">"https://sh.ch/CMS/Webseite/Kanton-Schaffhausen/Beh-rde/Verwaltung/Departement-des-Innern/Gesundheitsamt-7126057-DE.html"</string>
 
-    <!-- url for booking an appointment for vaccination for canton so -->
-    <string name="vaccination_booking_so_url">"https://so.ch/coronaimpfung"</string>
+	<!-- canton name sz -->
+	<string name="vaccination_booking_sz_name">"Schwyz"</string>
 
-    <!-- canton name tg -->
-    <string name="vaccination_booking_tg_name">"Thurgovia"</string>
+	<!-- url for booking an appointment for vaccination for canton sz -->
+	<string name="vaccination_booking_sz_url">"https://www.sz.ch/corona-impfen"</string>
 
-    <!-- url for booking an appointment for vaccination for canton tg -->
-    <string name="vaccination_booking_tg_url">"https://gesundheit.tg.ch/aktuelles/impfung-fuer-covid-19.html/11590"</string>
+	<!-- canton name so -->
+	<string name="vaccination_booking_so_name">"Solothurn"</string>
 
-    <!-- canton name ti -->
-    <string name="vaccination_booking_ti_name">"Ticino"</string>
+	<!-- url for booking an appointment for vaccination for canton so -->
+	<string name="vaccination_booking_so_url">"https://so.ch/coronaimpfung"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ti -->
-    <string name="vaccination_booking_ti_url">"http://www.ti.ch/vaccinazione"</string>
+	<!-- canton name tg -->
+	<string name="vaccination_booking_tg_name">"Thurgovia"</string>
 
-    <!-- canton name ur -->
-    <string name="vaccination_booking_ur_name">"Uri"</string>
+	<!-- url for booking an appointment for vaccination for canton tg -->
+	<string name="vaccination_booking_tg_url">"https://gesundheit.tg.ch/aktuelles/impfung-fuer-covid-19.html/11590"</string>
 
-    <!-- url for booking an appointment for vaccination for canton ur -->
-    <string name="vaccination_booking_ur_url">"https://www.ur.ch/themen/3673"</string>
+	<!-- canton name ti -->
+	<string name="vaccination_booking_ti_name">"Ticino"</string>
 
-    <!-- canton name vs -->
-    <string name="vaccination_booking_vs_name">"Valais"</string>
+	<!-- url for booking an appointment for vaccination for canton ti -->
+	<string name="vaccination_booking_ti_url">"http://www.ti.ch/vaccinazione"</string>
 
-    <!-- url for booking an appointment for vaccination for canton vs -->
-    <string name="vaccination_booking_vs_url">"https://www.vs.ch/de/web/coronavirus#ancre_vaccination"</string>
+	<!-- canton name ur -->
+	<string name="vaccination_booking_ur_name">"Uri"</string>
 
-    <!-- canton name vd -->
-    <string name="vaccination_booking_vd_name">"Vaud"</string>
+	<!-- url for booking an appointment for vaccination for canton ur -->
+	<string name="vaccination_booking_ur_url">"https://www.ur.ch/themen/3673"</string>
 
-    <!-- url for booking an appointment for vaccination for canton vd -->
-    <string name="vaccination_booking_vd_url">"https://vd.ch/coronavirus-vaccins"</string>
+	<!-- canton name vs -->
+	<string name="vaccination_booking_vs_name">"Valais"</string>
 
-    <!-- canton name zg -->
-    <string name="vaccination_booking_zg_name">"Zug"</string>
+	<!-- url for booking an appointment for vaccination for canton vs -->
+	<string name="vaccination_booking_vs_url">"https://www.vs.ch/de/web/coronavirus#ancre_vaccination"</string>
 
-    <!-- url for booking an appointment for vaccination for canton zg -->
-    <string name="vaccination_booking_zg_url">"https://www.corona-impfung-zug.ch/en/"</string>
+	<!-- canton name vd -->
+	<string name="vaccination_booking_vd_name">"Vaud"</string>
 
-    <!-- canton name zh -->
-    <string name="vaccination_booking_zh_name">"Zürich"</string>
+	<!-- url for booking an appointment for vaccination for canton vd -->
+	<string name="vaccination_booking_vd_url">"https://vd.ch/coronavirus-vaccins"</string>
 
-    <!-- url for booking an appointment for vaccination for canton zh -->
-    <string name="vaccination_booking_zh_url">"http://www.zh.ch/coronaimpfung"</string>
+	<!-- canton name zg -->
+	<string name="vaccination_booking_zg_name">"Zug"</string>
 
-    <!-- vaccination hint box title -->
-    <string name="vaccination_hint_title_2">"Get vaccinated today!"</string>
+	<!-- url for booking an appointment for vaccination for canton zg -->
+	<string name="vaccination_booking_zg_url">"https://www.corona-impfung-zug.ch/en/"</string>
 
-    <!-- vaccination hint box text -->
-    <string name="vaccination_hint_text_2">"Being vaccinated against COVID-19 means hassle-free travel to most countries. "</string>
+	<!-- canton name zh -->
+	<string name="vaccination_booking_zh_name">"Zürich"</string>
 
-    <!-- vaccination hint box title -->
-    <string name="vaccination_hint_title_3">"Get vaccinated today!"</string>
+	<!-- url for booking an appointment for vaccination for canton zh -->
+	<string name="vaccination_booking_zh_url">"http://www.zh.ch/coronaimpfung"</string>
 
-    <!-- vaccination hint box text -->
-    <string name="vaccination_hint_text_3">"Being vaccinated against COVID-19 means protection from infection and severe disease. "</string>
+	<!-- vaccination hint box title -->
+	<string name="vaccination_hint_title_2">"Get vaccinated today!"</string>
 
-    <!-- vaccination hint box title -->
-    <string name="vaccination_hint_title_4">"Get vaccinated today!"</string>
+	<!-- vaccination hint box text -->
+	<string name="vaccination_hint_text_2">"Being vaccinated against COVID-19 means hassle-free travel to most countries. "</string>
 
-    <!-- vaccination hint box text -->
-    <string name="vaccination_hint_text_4">"Being vaccinated against COVID-19 means immunity the safe way."</string>
+	<!-- vaccination hint box title -->
+	<string name="vaccination_hint_title_3">"Get vaccinated today!"</string>
 
-    <!-- vaccination hint box title -->
-    <string name="vaccination_hint_title_5">"Get vaccinated today!"</string>
+	<!-- vaccination hint box text -->
+	<string name="vaccination_hint_text_3">"Being vaccinated against COVID-19 means protection from infection and severe disease. "</string>
 
-    <!-- vaccination hint box text -->
-    <string name="vaccination_hint_text_5">"Being vaccinated against COVID-19 means helping to reduce the disease burden. "</string>
+	<!-- vaccination hint box title -->
+	<string name="vaccination_hint_title_4">"Get vaccinated today!"</string>
 
-    <!-- vaccination hint box title -->
-    <string name="vaccination_hint_title_6">"Get vaccinated today!"</string>
+	<!-- vaccination hint box text -->
+	<string name="vaccination_hint_text_4">"Being vaccinated against COVID-19 means immunity the safe way."</string>
 
-    <!-- vaccination hint box text -->
-    <string name="vaccination_hint_text_6">"Being vaccinated against COVID-19 means helping to control the impact of the pandemic. "</string>
+	<!-- vaccination hint box title -->
+	<string name="vaccination_hint_title_5">"Get vaccinated today!"</string>
 
-    <!-- vaccination hint box title -->
-    <string name="vaccination_hint_title_7">"Get vaccinated today!"</string>
+	<!-- vaccination hint box text -->
+	<string name="vaccination_hint_text_5">"Being vaccinated against COVID-19 means helping to reduce the disease burden. "</string>
 
-    <!-- vaccination hint box text -->
-    <string name="vaccination_hint_text_7">"Being vaccinated against COVID-19 means preventing long COVID."</string>
+	<!-- vaccination hint box title -->
+	<string name="vaccination_hint_title_6">"Get vaccinated today!"</string>
 
-    <!-- vaccination hint box title -->
-    <string name="vaccination_hint_title_8">"Get vaccinated today!"</string>
+	<!-- vaccination hint box text -->
+	<string name="vaccination_hint_text_6">"Being vaccinated against COVID-19 means helping to control the impact of the pandemic. "</string>
 
-    <!-- vaccination hint box text -->
-    <string name="vaccination_hint_text_8">"Being vaccinated against COVID-19 means helping to relieve the pressure on the health system."</string>
+	<!-- vaccination hint box title -->
+	<string name="vaccination_hint_title_7">"Get vaccinated today!"</string>
 
-    <!-- vaccination booking info screen title -->
-    <string name="vaccination_booking_info_title">"Book a vaccination appointment near you"</string>
+	<!-- vaccination hint box text -->
+	<string name="vaccination_hint_text_7">"Being vaccinated against COVID-19 means preventing long COVID."</string>
 
-    <!-- vaccination booking info screen text -->
-    <string name="vaccination_booking_info_text">"Vaccination may be performed at the following locations near you:
+	<!-- vaccination hint box title -->
+	<string name="vaccination_hint_title_8">"Get vaccinated today!"</string>
+
+	<!-- vaccination hint box text -->
+	<string name="vaccination_hint_text_8">"Being vaccinated against COVID-19 means helping to relieve the pressure on the health system."</string>
+
+	<!-- vaccination booking info screen title -->
+	<string name="vaccination_booking_info_title">"Book a vaccination appointment near you"</string>
+
+	<!-- vaccination booking info screen text -->
+	<string name="vaccination_booking_info_text">"Vaccination may be performed at the following locations near you:
 
 - at specific vaccination centres
 - in hospitals
@@ -1218,522 +1217,524 @@ The 'Certificate light' is only available electronically in the app and is only 
 
 Many places also offer walk-in vaccinations without an appointment."</string>
 
-    <!-- vaccination booking info screen info box at bottom -->
-    <string name="vaccination_booking_info_info">"The COVID-19 vaccination is recommended for those over 5. "</string>
+	<!-- vaccination booking info screen info box at bottom -->
+	<string name="vaccination_booking_info_info">"The COVID-19 vaccination is recommended for those over 5. "</string>
 
-    <!-- Header on vaccination appointment screen -->
-    <string name="vaccination_appointment_header">"Vaccination appointment"</string>
+	<!-- Header on vaccination appointment screen -->
+	<string name="vaccination_appointment_header">"Vaccination appointment"</string>
 
-    <!-- Book vaccination appointment button title on homescreen -->
-    <string name="vaccination_homescreen_button_title">"Book a vaccination appointment"</string>
+	<!-- Book vaccination appointment button title on homescreen -->
+	<string name="vaccination_homescreen_button_title">"Book a vaccination appointment"</string>
 
-    <!-- Choose your canton title in vaccination appointment screen -->
-    <string name="vaccination_choose_your_canton">"Select your canton"</string>
+	<!-- Choose your canton title in vaccination appointment screen -->
+	<string name="vaccination_choose_your_canton">"Select your canton"</string>
 
-    <!-- Link title for more information about the vaccine -->
-    <string name="vaccination_more_information_title">"More information about the COVID-19 vaccination"</string>
+	<!-- Link title for more information about the vaccine -->
+	<string name="vaccination_more_information_title">"More information about the COVID-19 vaccination"</string>
 
-    <!-- Button text for information about the vaccine at the bottom of the certificate -->
-    <string name="vaccination_information_button_in_certificate">"Information on vaccination "</string>
+	<!-- Button text for information about the vaccine at the bottom of the certificate -->
+	<string name="vaccination_information_button_in_certificate">"Information on vaccination "</string>
 
-    <!-- Vaccination Booking Info URL Link -->
-    <string name="vaccination_booking_info_url">"https://foph-coronavirus.ch/vaccination/"</string>
+	<!-- Vaccination Booking Info URL Link -->
+	<string name="vaccination_booking_info_url">"https://foph-coronavirus.ch/vaccination/"</string>
 
-    <!-- Show information if special hardware detected  -->
-    <string name="verifier_qr_scanner_external_hardware_detected">"External hardware scanner detected"</string>
+	<!-- Show information if special hardware detected  -->
+	<string name="verifier_qr_scanner_external_hardware_detected">"External hardware scanner detected"</string>
 
-    <!-- Error popup reset button text -->
-    <string name="error_decryption_reset_button">"Reset"</string>
+	<!-- Error popup reset button text -->
+	<string name="error_decryption_reset_button">"Reset"</string>
 
-    <!-- Text Certificate Could not be loaded {ERROR_CODE} gets replaces with the error code -->
-    <string name="error_decryption_text">"Certificates could not be loaded
+	<!-- Text Certificate Could not be loaded {ERROR_CODE} gets replaces with the error code -->
+	<string name="error_decryption_text">"Certificates could not be loaded
 
 Code: {ERROR_CODE}"</string>
-    <string name="covid_certificate_sero_positiv_test_title">"Recovery (Antibody)"</string>
-    <string name="wallet_time_inconsistency_error_title">"Checking not possible"</string>
-    <string name="wallet_time_inconsistency_error_text">"Date, time or time zone on the device are set incorrectly."</string>
-    <string name="wallet_info_box_certificate_scan_title">"Do you want to check certificates?"</string>
-    <string name="wallet_info_box_certificate_scan_text">"For quicker checking that is data privacy compliant, use the COVID Certificate Check app"</string>
-    <string name="wallet_info_box_certificate_scan_button_check_app">"To the Check-App"</string>
-    <string name="wallet_info_box_certificate_scan_close">"Understood"</string>
-    <string name="wallet_info_box_certificate_scan_text_bold">"«COVID Certificate Check»-App."</string>
-    <string name="wallet_only_valid_in_switzerland">"Not valid outside Switzerland"</string>
-    <string name="covid_certificate_sero_positiv_test_befund_label">"Finding"</string>
-    <string name="covid_certificate_sero_positiv_test_befund_value">"Sufficient"</string>
+	<string name="covid_certificate_sero_positiv_test_title">"Recovery (Antibody)"</string>
+	<string name="wallet_time_inconsistency_error_title">"Checking not possible"</string>
+	<string name="wallet_time_inconsistency_error_text">"Date, time or time zone on the device are set incorrectly."</string>
+	<string name="wallet_info_box_certificate_scan_title">"Do you want to check certificates?"</string>
+	<string name="wallet_info_box_certificate_scan_text">"For quicker checking that is data privacy compliant, use the COVID Certificate Check app"</string>
+	<string name="wallet_info_box_certificate_scan_button_check_app">"To the Check-App"</string>
+	<string name="wallet_info_box_certificate_scan_close">"Understood"</string>
+	<string name="wallet_info_box_certificate_scan_text_bold">"«COVID Certificate Check»-App."</string>
+	<string name="wallet_only_valid_in_switzerland">"Not valid outside Switzerland"</string>
+	<string name="covid_certificate_sero_positiv_test_befund_label">"Finding"</string>
+	<string name="covid_certificate_sero_positiv_test_befund_value">"Sufficient"</string>
 
-    <!-- Ausnahme Test Zertifikat Detail: Titel für Startdatum des Attests -->
-    <string name="wallet_certificate_ausnahme_test_attest_start_date">"Start of validity"</string>
+	<!-- Ausnahme Test Zertifikat Detail: Titel für Startdatum des Attests -->
+	<string name="wallet_certificate_ausnahme_test_attest_start_date">"Start of validity"</string>
 
-    <!-- Ausnahme Test Zertifikat Detail: Titel für verantwortliche Stelle für Ausstellung -->
-    <string name="wallet_certificate_ausnahme_responsible_issuer">"Issuing office"</string>
+	<!-- Ausnahme Test Zertifikat Detail: Titel für verantwortliche Stelle für Ausstellung -->
+	<string name="wallet_certificate_ausnahme_responsible_issuer">"Issuing office"</string>
 
-    <!-- Testname für Schweizer Ausnahme Zertifikat für Nicht-Testbare und Nicht-Impfbare Personen -->
-    <string name="covid_certificate_ch_ausnahme_test_title">"Exemption certificate"</string>
-    <string name="infobox_update_title">"New version available"</string>
-    <string name="infobox_update_text">"Download the latest version of the app."</string>
-    <string name="infobox_update_button">"Update"</string>
+	<!-- Testname für Schweizer Ausnahme Zertifikat für Nicht-Testbare und Nicht-Impfbare Personen -->
+	<string name="covid_certificate_ch_ausnahme_test_title">"Exemption certificate"</string>
+	<string name="infobox_update_title">"New version available"</string>
+	<string name="infobox_update_text">"Download the latest version of the app."</string>
+	<string name="infobox_update_button">"Update"</string>
 
-    <!-- vaccination booking  screen info about Impf-Check (impf-check.ch) -->
-    <string name="vaccination_impf_check_info_text">"The COVID-19 Vaccination Check provides information on initial and booster vaccinations and guides you to the relevant point of contact in your canton."</string>
+	<!-- vaccination booking  screen info about Impf-Check (impf-check.ch) -->
+	<string name="vaccination_impf_check_info_text">"The COVID-19 Vaccination Check provides information on initial and booster vaccinations and guides you to the relevant point of contact in your canton."</string>
 
-    <!-- button title for link to impf-check.ch -->
-    <string name="vaccination_impf_check_action">"To the Vaccination Check"</string>
+	<!-- button title for link to impf-check.ch -->
+	<string name="vaccination_impf_check_action">"To the Vaccination Check"</string>
 
-    <!-- URL to ImpfCheck -->
-    <string name="vaccination_impf_check_url">"https://covid19.impf-check.ch/"</string>
-    <string name="vaccination_impf_check_title">"Book an appointment now"</string>
-    <string name="verifier_faq_works_linktext_1">"Explanatory video"</string>
-    <string name="verifier_faq_works_linkurl_1">"https://youtu.be/spfVPMqukjM"</string>
+	<!-- URL to ImpfCheck -->
+	<string name="vaccination_impf_check_url">"https://covid19.impf-check.ch/"</string>
+	<string name="vaccination_impf_check_title">"Book an appointment now"</string>
+	<string name="verifier_faq_works_linktext_1">"Explanatory video"</string>
+	<string name="verifier_faq_works_linkurl_1">"https://youtu.be/spfVPMqukjM"</string>
 
-    <!-- Title of button to choose verification mode -->
-    <string name="verifier_choose_mode_button_title">"Select"</string>
+	<!-- Title of button to choose verification mode -->
+	<string name="verifier_choose_mode_button_title">"Select"</string>
 
-    <!-- 👍 -->
-    <!-- Verifier app scan button with indication of mode -->
-    <string name="verifier_homescreen_scan_button_with_mode">"Verify ({MODE})"</string>
+	<!-- 👍 -->
+	<!-- Verifier app scan button with indication of mode -->
+	<string name="verifier_homescreen_scan_button_with_mode">"Verify ({MODE})"</string>
 
-    <!-- error if scan was performed with a no longer existing mode -->
-    <string name="verifier_error_mode_no_longer_exists">"Your selected verification mode no longer exists."</string>
+	<!-- error if scan was performed with a no longer existing mode -->
+	<string name="verifier_error_mode_no_longer_exists">"Your selected verification mode no longer exists."</string>
 
-    <!-- 👍 -->
-    <!-- title for info pop-up in wallet app describing the validation states for the different check modes -->
-    <string name="wallet_check_mode_info_title">"Info"</string>
+	<!-- 👍 -->
+	<!-- title for info pop-up in wallet app describing the validation states for the different check modes -->
+	<string name="wallet_check_mode_info_title">"Info"</string>
 
-    <!-- 👍 -->
-    <!-- text for info pop-up in wallet app describing 2G OK state -->
-    <string name="wallet_check_mode_info_2g_ok_text">"Access to organisations and events permitted for people who have been vaccinated or who have recovered."</string>
+	<!-- 👍 -->
+	<!-- text for info pop-up in wallet app describing 2G OK state -->
+	<string name="wallet_check_mode_info_2g_ok_text">"Access to organisations and events permitted for people who have been vaccinated or who have recovered."</string>
 
-    <!-- 👍 -->
-    <!-- text for info pop-up in wallet app describing 2G NOT OK state -->
-    <string name="wallet_check_mode_info_2g_not_ok_text">"Access not permitted."</string>
+	<!-- 👍 -->
+	<!-- text for info pop-up in wallet app describing 2G NOT OK state -->
+	<string name="wallet_check_mode_info_2g_not_ok_text">"Access not permitted."</string>
 
-    <!-- 👍 -->
-    <!-- check app -> check mode select pop-up -> display name of check mode 3G -->
-    <string name="verifier_check_mode_info_3g_title">"3G"</string>
+	<!-- 👍 -->
+	<!-- check app -> check mode select pop-up -> display name of check mode 3G -->
+	<string name="verifier_check_mode_info_3g_title">"3G"</string>
 
-    <!-- 👍 -->
-    <!-- check app -> check mode select pop-up -> display name of check mode 2G -->
-    <string name="verifier_check_mode_info_2g_title">"2G"</string>
+	<!-- 👍 -->
+	<!-- check app -> check mode select pop-up -> display name of check mode 2G -->
+	<string name="verifier_check_mode_info_2g_title">"2G"</string>
 
-    <!-- 👍 -->
-    <!-- check app -> check mode select pop-up -> info text for check mode 3g -->
-    <string name="verifier_check_mode_info_3g_text_1">"For organisations and events applying the 3G rule."</string>
+	<!-- 👍 -->
+	<!-- check app -> check mode select pop-up -> info text for check mode 3g -->
+	<string name="verifier_check_mode_info_3g_text_1">"For organisations and events applying the 3G rule."</string>
 
-    <!-- 👍 -->
-    <!-- check app -> check mode select pop-up -> info text for check mode 3g -->
-    <string name="verifier_check_mode_info_3g_text_2">"In this mode, COVID certificates are accepted for people who have been vaccinated, or who have recovered or tested negative."</string>
+	<!-- 👍 -->
+	<!-- check app -> check mode select pop-up -> info text for check mode 3g -->
+	<string name="verifier_check_mode_info_3g_text_2">"In this mode, COVID certificates are accepted for people who have been vaccinated, or who have recovered or tested negative."</string>
 
-    <!-- 👍 -->
-    <!-- check app -> check mode select pop-up -> info text for check mode 3g -->
-    <string name="verifier_check_mode_info_3g_text_3">"It is possible to verify a \"light\" certificate in this mode."</string>
+	<!-- 👍 -->
+	<!-- check app -> check mode select pop-up -> info text for check mode 3g -->
+	<string name="verifier_check_mode_info_3g_text_3">"It is possible to verify a \"light\" certificate in this mode."</string>
 
-    <!-- 👍 -->
-    <!-- check app -> check mode select pop-up -> info text for check mode 2g -->
-    <string name="verifier_check_mode_info_2g_text_1">"For organisations and events applying the 2G rule."</string>
+	<!-- 👍 -->
+	<!-- check app -> check mode select pop-up -> info text for check mode 2g -->
+	<string name="verifier_check_mode_info_2g_text_1">"For organisations and events applying the 2G rule."</string>
 
-    <!-- 👍 -->
-    <!-- check app -> check mode select pop-up -> info text for check mode 2g -->
-    <string name="verifier_check_mode_info_2g_text_2">"In this mode, COVID certificates are accepted for people who have been vaccinated or who have recovered."</string>
+	<!-- 👍 -->
+	<!-- check app -> check mode select pop-up -> info text for check mode 2g -->
+	<string name="verifier_check_mode_info_2g_text_2">"In this mode, COVID certificates are accepted for people who have been vaccinated or who have recovered."</string>
 
-    <!-- 👍 -->
-    <!-- check app -> check mode select pop-up -> info text for check mode 2g -->
-    <string name="verifier_check_mode_info_2g_text_3">"It is not possible to verify a \"light\" certificate in this mode."</string>
+	<!-- 👍 -->
+	<!-- check app -> check mode select pop-up -> info text for check mode 2g -->
+	<string name="verifier_check_mode_info_2g_text_3">"It is not possible to verify a \"light\" certificate in this mode."</string>
 
-    <!-- 👍 -->
-    <!-- Verifier: Modus auswählen Titel -->
-    <string name="verifier_mode_title">"Verification mode"</string>
+	<!-- 👍 -->
+	<!-- Verifier: Modus auswählen Titel -->
+	<string name="verifier_mode_title">"Verification mode"</string>
 
-    <!-- 👍 -->
-    <!-- text for info pop-up in wallet app describing 3G OK state -->
-    <string name="wallet_check_mode_info_3g_ok_text">"Access to organisations and events permitted for people who have been vaccinated, or who have recovered or tested negative."</string>
+	<!-- 👍 -->
+	<!-- text for info pop-up in wallet app describing 3G OK state -->
+	<string name="wallet_check_mode_info_3g_ok_text">"Access to organisations and events permitted for people who have been vaccinated, or who have recovered or tested negative."</string>
 
-    <!-- 👍 -->
-    <!-- text for info pop-up in wallet app describing 3G NOT OK state -->
-    <string name="wallet_check_mode_info_3g_not_ok_text">"Access not permitted."</string>
+	<!-- 👍 -->
+	<!-- text for info pop-up in wallet app describing 3G NOT OK state -->
+	<string name="wallet_check_mode_info_3g_not_ok_text">"Access not permitted."</string>
 
-    <!-- Titel für Fehler wenn Modus Light-Zertifikat nicht unterstützt -->
-    <string name="verifier_verify_light_not_supported_by_mode_title">"The COVID certificate being verified is a \"light\" certificate. This cannot be verified in {MODUS} verification mode."</string>
+	<!-- Titel für Fehler wenn Modus Light-Zertifikat nicht unterstützt -->
+	<string name="verifier_verify_light_not_supported_by_mode_title">"The COVID certificate being verified is a \"light\" certificate. This cannot be verified in {MODUS} verification mode."</string>
 
-    <!-- Text für Fehler wenn Modus Light-Zertifikat nicht unterstützt -->
-    <string name="verifier_verify_light_not_supported_by_mode_text">"In this case, the certificate can be verified only if the conversion to a \"light\" certificate is reversed."</string>
+	<!-- Text für Fehler wenn Modus Light-Zertifikat nicht unterstützt -->
+	<string name="verifier_verify_light_not_supported_by_mode_text">"In this case, the certificate can be verified only if the conversion to a \"light\" certificate is reversed."</string>
 
-    <!-- check app -> check mode select pop-up -> info text when no check mode is selected -->
-    <string name="verifier_check_mode_info_unselected_text_1">"Select the verification mode that you want to use for verifying COVID certificates."</string>
+	<!-- check app -> check mode select pop-up -> info text when no check mode is selected -->
+	<string name="verifier_check_mode_info_unselected_text_1">"Select the verification mode that you want to use for verifying COVID certificates."</string>
 
-    <!-- check app -> check mode select pop-up -> info text when no check mode is selected -->
-    <string name="verifier_check_mode_info_unselected_text_2">"The verification mode can be changed at any time."</string>
+	<!-- check app -> check mode select pop-up -> info text when no check mode is selected -->
+	<string name="verifier_check_mode_info_unselected_text_2">"The verification mode can be changed at any time."</string>
 
-    <!-- check app -> check mode select pop-up -> display name of check mode 2G+ -->
-    <string name="verifier_check_mode_info_2g_plus_title">"2G+"</string>
+	<!-- check app -> check mode select pop-up -> display name of check mode 2G+ -->
+	<string name="verifier_check_mode_info_2g_plus_title">"2G+"</string>
 
-    <!-- check app -> check mode select pop-up -> info text for check mode 2G+ -->
-    <string name="verifier_check_mode_info_2g_plus_text_1">"For organisations and events applying the 2G+ rule."</string>
+	<!-- check app -> check mode select pop-up -> info text for check mode 2G+ -->
+	<string name="verifier_check_mode_info_2g_plus_text_1">"For organisations and events applying the 2G+ rule."</string>
 
-    <!-- check app -> check mode select pop-up -> info text for check mode 2G+ -->
-    <string name="verifier_check_mode_info_2g_plus_text_2">"In addition to a COVID certificate for people who have been vaccinated or who have recovered, a valid test certificate is required. This must be verified separately."</string>
+	<!-- check app -> check mode select pop-up -> info text for check mode 2G+ -->
+	<string name="verifier_check_mode_info_2g_plus_text_2">"In addition to a COVID certificate for people who have been vaccinated or who have recovered, a valid test certificate is required. This must be verified separately."</string>
 
-    <!-- check app -> check mode select pop-up -> info text for check mode 2G+ -->
-    <string name="verifier_check_mode_info_2g_plus_text_3">"Exceptions: People who have been fully vaccinated, received a booster vaccination or recovered (based on a PCR test) no longer than 120 days ago"</string>
+	<!-- check app -> check mode select pop-up -> info text for check mode 2G+ -->
+	<string name="verifier_check_mode_info_2g_plus_text_3">"Exceptions: People who have been fully vaccinated, received a booster vaccination or recovered (based on a PCR test) no longer than 120 days ago"</string>
 
-    <!-- check app -> check mode select pop-up -> info text for check mode 2G+ -->
-    <string name="verifier_check_mode_info_2g_plus_text_4">"It is not possible to verify \"light\" certificates in this mode."</string>
+	<!-- check app -> check mode select pop-up -> info text for check mode 2G+ -->
+	<string name="verifier_check_mode_info_2g_plus_text_4">"It is not possible to verify \"light\" certificates in this mode."</string>
 
-    <!-- 2G+: Anzeige, dass Zertifikat 2G erfüllt -->
-    <string name="verifier_2g_plus_success2g">"Valid COVID certificate under the 2G rule"</string>
+	<!-- 2G+: Anzeige, dass Zertifikat 2G erfüllt -->
+	<string name="verifier_2g_plus_success2g">"Valid COVID certificate under the 2G rule"</string>
 
-    <!-- 2G+: Info, dass Zertifikat + erfüllt -->
-    <string name="verifier_2g_plus_successplus">"Valid COVID certificate for people who have been tested."</string>
+	<!-- 2G+: Info, dass Zertifikat + erfüllt -->
+	<string name="verifier_2g_plus_successplus">"Valid COVID certificate for people who have been tested."</string>
 
-    <!-- Verifier: 2G+ Info, dass noch + nötig -->
-    <string name="verifier_2g_plus_infoplus">"Permitted for 2G+ only when combined with a valid test certificate."</string>
+	<!-- Verifier: 2G+ Info, dass noch + nötig -->
+	<string name="verifier_2g_plus_infoplus">"Permitted for 2G+ only when combined with a valid test certificate."</string>
 
-    <!-- Verifier: 2G+ Info dass noch 2G nötig -->
-    <string name="verifier_2g_plus_info2g">"Permitted for 2G+ only when combined with verification of a COVID certificate for people who have been vaccinated or have recovered."</string>
+	<!-- Verifier: 2G+ Info dass noch 2G nötig -->
+	<string name="verifier_2g_plus_info2g">"Permitted for 2G+ only when combined with verification of a COVID certificate for people who have been vaccinated or have recovered."</string>
 
-    <!-- Prüfung fehlgeschlagen App update nötig -->
-    <string name="verifier_error_app_store_text">"To verify this type of COVID certificate, you must have the latest version of the app. Please update your app and repeat the verification process."</string>
+	<!-- Prüfung fehlgeschlagen App update nötig -->
+	<string name="verifier_error_app_store_text">"To verify this type of COVID certificate, you must have the latest version of the app. Please update your app and repeat the verification process."</string>
 
-    <!-- Button Text für Prüfung fehlgeschlagen App update nötig  -->
-    <string name="verifier_error_app_store_button">"To the App Store"</string>
+	<!-- Button Text für Prüfung fehlgeschlagen App update nötig  -->
+	<string name="verifier_error_app_store_button">"To the App Store"</string>
 
-    <!-- check app -> check mode select pop-up -> display name of check mode Testzertifikat -->
-    <string name="verifier_check_mode_info_test_cert_title">"Test certificate"</string>
+	<!-- check app -> check mode select pop-up -> display name of check mode Testzertifikat -->
+	<string name="verifier_check_mode_info_test_cert_title">"Test certificate"</string>
 
-    <!-- check app -> check mode select pop-up -> info text for check mode Testzertifikat -->
-    <string name="verifier_check_mode_info_test_cert_text_1">"For areas in which a valid test certificate is required."</string>
+	<!-- check app -> check mode select pop-up -> info text for check mode Testzertifikat -->
+	<string name="verifier_check_mode_info_test_cert_text_1">"For areas in which a valid test certificate is required."</string>
 
-    <!-- check app -> check mode select pop-up -> info text for check mode Testzertifikat -->
-    <string name="verifier_check_mode_info_test_cert_text_2">"In this mode, COVID certificates are accepted for people who have tested negative based on a PCR or rapid antigen test."</string>
+	<!-- check app -> check mode select pop-up -> info text for check mode Testzertifikat -->
+	<string name="verifier_check_mode_info_test_cert_text_2">"In this mode, COVID certificates are accepted for people who have tested negative based on a PCR or rapid antigen test."</string>
 
-    <!-- check app -> check mode select pop-up -> info text for check mode Testzertifikat -->
-    <string name="verifier_check_mode_info_test_cert_text_3">"It is not possible to verify \"light\" certificates in this mode."</string>
+	<!-- check app -> check mode select pop-up -> info text for check mode Testzertifikat -->
+	<string name="verifier_check_mode_info_test_cert_text_3">"It is not possible to verify \"light\" certificates in this mode."</string>
 
-    <!-- wallet refresh button removal info box text -->
-    <string name="wallet_refresh_button_info_text_1">"The \"Refresh button\" has been removed."</string>
+	<!-- wallet refresh button removal info box text -->
+	<string name="wallet_refresh_button_info_text_1">"The \"Refresh button\" has been removed."</string>
 
-    <!-- wallet refresh button removal info box text -->
-    <string name="wallet_refresh_button_info_text_2">"If your COVID certificate has expired or is technically invalid, this is indicated directly on the certificate."</string>
+	<!-- wallet refresh button removal info box text -->
+	<string name="wallet_refresh_button_info_text_2">"If your COVID certificate has expired or is technically invalid, this is indicated directly on the certificate."</string>
 
-    <!-- wallet refresh button removal info box text -->
-    <string name="wallet_refresh_button_info_text_3">"COVID certificates are to be verified with the \"COVID Certificate Check\" app."</string>
+	<!-- wallet refresh button removal info box text -->
+	<string name="wallet_refresh_button_info_text_3">"COVID certificates are to be verified with the \"COVID Certificate Check\" app."</string>
 
-    <!-- wallet refresh button removal info box fat title above text 3 -->
-    <string name="wallet_refresh_button_info_fat_title_3">"For verifiers"</string>
+	<!-- wallet refresh button removal info box fat title above text 3 -->
+	<string name="wallet_refresh_button_info_fat_title_3">"For verifiers"</string>
 
-    <!-- wallet refresh button removal info box link text -->
-    <string name="wallet_refresh_button_info_link_text">"To find out more"</string>
+	<!-- wallet refresh button removal info box link text -->
+	<string name="wallet_refresh_button_info_link_text">"To find out more"</string>
 
-    <!-- wallet refresh button removal info box link url -->
-    <string name="wallet_refresh_button_info_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/covid-zertifikat/covid-zertifikat-pruefer-aussteller-technische-informationen.html#1851413288"</string>
+	<!-- wallet refresh button removal info box link url -->
+	<string name="wallet_refresh_button_info_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/covid-zertifikat/covid-zertifikat-pruefer-aussteller-technische-informationen.html#1851413288"</string>
 
-    <!-- text for info pop-up in wallet app describing 2G+ OK state -->
-    <string name="wallet_check_mode_info_2g_plus_ok_text">"Access to organisations and events permitted for people who have been fully vaccinated, have received a booster jab or have recovered (based on PCR test results) in the preceding 120 days; an additional test certificate is not required."</string>
+	<!-- text for info pop-up in wallet app describing 2G+ OK state -->
+	<string name="wallet_check_mode_info_2g_plus_ok_text">"Access to organisations and events permitted for people who have been fully vaccinated, have received a booster jab or have recovered (based on PCR test results) in the preceding 120 days; an additional test certificate is not required."</string>
 
-    <!-- text for info pop-up in wallet app describing 2G+ NOT OK state -->
-    <string name="wallet_check_mode_info_2g_plus_not_ok_text">"To gain access to organisations and events, a negative test result is required in addition to the COVID certificate for people who have been vaccinated or have recovered."</string>
+	<!-- text for info pop-up in wallet app describing 2G+ NOT OK state -->
+	<string name="wallet_check_mode_info_2g_plus_not_ok_text">"To gain access to organisations and events, a negative test result is required in addition to the COVID certificate for people who have been vaccinated or have recovered."</string>
 
-    <!-- wallet refresh button removal info box title -->
-    <string name="wallet_refresh_button_info_title">"Info"</string>
+	<!-- wallet refresh button removal info box title -->
+	<string name="wallet_refresh_button_info_title">"Info"</string>
 
-    <!-- Ausnahme-Zertifikat: Medizinisches Attest ausgestellt in -->
-    <string name="wallet_certificate_ausnahme_issued_country">"Medical certificate issued in"</string>
+	<!-- Ausnahme-Zertifikat: Medizinisches Attest ausgestellt in -->
+	<string name="wallet_certificate_ausnahme_issued_country">"Medical certificate issued in"</string>
 
-    <!-- Wallet: Hinweis im Zertifikat Detail für Ausnahme Zertifikat -->
-    <string name="wallet_certificate_detail_note_ausnahme">"This certificate is not a travel document.
+	<!-- Wallet: Hinweis im Zertifikat Detail für Ausnahme Zertifikat -->
+	<string name="wallet_certificate_detail_note_ausnahme">"This certificate is not a travel document.
 &lt;br /&gt;&lt;br /&gt;
 This certificate is only valid for a limited period of time. You can check the current duration of validity in Switzerland at any time using the COVID Certificate app."</string>
 
-    <!-- Wallet: Ausnahme Label für Liste -->
-    <string name="covid_certificate_ch_ausnahme_list_label">"Exception"</string>
+	<!-- Wallet: Ausnahme Label für Liste -->
+	<string name="covid_certificate_ch_ausnahme_list_label">"Exception"</string>
 
-    <!-- Wallet: Titel von einem positivem Antigen-Test -->
-    <string name="covid_certificate_antigen_positive_test">"Recovery (Antigen Rapid Test)"</string>
+	<!-- Wallet: Titel von einem positivem Antigen-Test -->
+	<string name="covid_certificate_antigen_positive_test">"Recovery (Antigen Rapid Test)"</string>
 
-    <!-- Wallet: Antigen Positive Titel von Testdatum -->
-    <string name="wallet_certificate_antigen_positive_date">"Date of first positive test result"</string>
+	<!-- Wallet: Antigen Positive Titel von Testdatum -->
+	<string name="wallet_certificate_antigen_positive_date">"Date of first positive test result"</string>
 
-    <!-- Wallet: Blaue Box für positiven Antigen-Test -->
-    <string name="wallet_certificate_detail_note_positive_antigen">"This certificate is not a travel document.
+	<!-- Wallet: Blaue Box für positiven Antigen-Test -->
+	<string name="wallet_certificate_detail_note_positive_antigen">"This certificate is not a travel document.
 &lt;br /&gt;&lt;br /&gt;
 This certificate is only valid for a limited period of time. You can check the current duration of validity in Switzerland at any time using the COVID Certificate app."</string>
 
-    <!-- banner title on homescreen. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_homescreen_title">"Imminent expiry"</string>
+	<!-- banner title on homescreen. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_homescreen_title">"Imminent expiry"</string>
 
-    <!-- banner title in certificate detail view. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_detail_title">"Info"</string>
+	<!-- banner title in certificate detail view. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_detail_title">"Info"</string>
 
-    <!-- banner text in certificate detail view. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_detail_text">"This certificate will soon expire."</string>
+	<!-- banner text in certificate detail view. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_detail_text">"This certificate will soon expire."</string>
 
-    <!-- more info 'button' text in banner in certicate detail view. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_detail_more_info">"More information?"</string>
+	<!-- more info 'button' text in banner in certicate detail view. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_detail_more_info">"More information?"</string>
 
-    <!-- title for pop up. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_popup_title">"Info"</string>
+	<!-- title for pop up. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_popup_title">"Info"</string>
 
-    <!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_popup_text1"></string>
+	<!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_popup_text1"></string>
 
-    <!-- bold text box for pop up. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_popup_bold_text">"This COVID certificate is valid for only a few more days. Please note the expiry date shown on the certificate."</string>
+	<!-- bold text box for pop up. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_popup_bold_text">"This COVID certificate is valid for only a few more days. Please note the expiry date shown on the certificate."</string>
 
-    <!-- link text for pop up. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_popup_link_text">"And now?"</string>
+	<!-- link text for pop up. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_popup_link_text">"And now?"</string>
 
-    <!-- link url for pop up. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_popup_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/what-should-i-do-if-my-covid-certificate-about-expire-under-swiss-rules-validity"</string>
+	<!-- link url for pop up. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_popup_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/what-should-i-do-if-my-covid-certificate-about-expire-under-swiss-rules-validity"</string>
 
-    <!-- banner title on homescreen. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_homescreen_title">"Shortened period of validity"</string>
+	<!-- banner title on homescreen. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_homescreen_title">"Shortened period of validity"</string>
 
-    <!-- banner title in certificate detail view. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_detail_title">"Shortened period of validity"</string>
+	<!-- banner title in certificate detail view. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_detail_title">"Shortened period of validity"</string>
 
-    <!-- banner text in certificate detail view. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_detail_text">"This certificate will soon expire."</string>
+	<!-- banner text in certificate detail view. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_detail_text">"This certificate will soon expire."</string>
 
-    <!-- more info 'button' text in banner in certicate detail view. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_detail_more_info">"More information"</string>
+	<!-- more info 'button' text in banner in certicate detail view. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_detail_more_info">"More information"</string>
 
-    <!-- title for pop up. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_popup_title">"Info"</string>
+	<!-- title for pop up. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_popup_title">"Info"</string>
 
-    <!-- text for pop up. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_popup_text1">"As of 31 Jan 2022 a shortened period of validity of 270 instead of 365 days applies to COVID vaccination or recovery certificates in Switzerland. This certificate is directly affected by the shortened period of validity:"</string>
+	<!-- text for pop up. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_popup_text1">"As of 31 Jan 2022 a shortened period of validity of 270 instead of 365 days applies to COVID vaccination or recovery certificates in Switzerland. This certificate is directly affected by the shortened period of validity:"</string>
 
-    <!-- bold text box for pop up. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_popup_bold_text">"This COVID certificate can no longer be used after 31 Jan 2022 as the period of validity will already have expired."</string>
+	<!-- bold text box for pop up. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_popup_bold_text">"This COVID certificate can no longer be used after 31 Jan 2022 as the period of validity will already have expired."</string>
 
-    <!-- link text for pop up. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_popup_link_text">"More information"</string>
+	<!-- link text for pop up. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_popup_link_text">"More information"</string>
 
-    <!-- link url for pop up. case: certificate will be invalid at time of validity change. -->
-    <string name="wallet_eol_banner_invalid_from_first_february_popup_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/why-period-validity-certificates-vaccination-or-recovery-being-shortened-365-270"</string>
+	<!-- link url for pop up. case: certificate will be invalid at time of validity change. -->
+	<string name="wallet_eol_banner_invalid_from_first_february_popup_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/why-period-validity-certificates-vaccination-or-recovery-being-shortened-365-270"</string>
 
-    <!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
-    <string name="wallet_eol_banner_invalid_in_three_weeks_popup_text2"></string>
-    <string name="infobox_generic_title">"Back up your certificate!"</string>
-    <string name="infobox_generic_text">"If you uninstall the app or change or lose your smartphone, you will also lose your COVID certificates.
+	<!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
+	<string name="wallet_eol_banner_invalid_in_three_weeks_popup_text2"></string>
+	<string name="infobox_generic_title">"Back up your certificate!"</string>
+	<string name="infobox_generic_text">"If you uninstall the app or change or lose your smartphone, you will also lose your COVID certificates.
 This means you should also keep a copy of your certificates outside the app by exporting them as PDFs."</string>
-    <string name="infobox_generic_button">"Find out more"</string>
-    <string name="infobox_generic_url_android">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i"</string>
-    <string name="infobox_generic_url_ios">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i"</string>
+	<string name="infobox_generic_button">"Find out more"</string>
+	<string name="infobox_generic_url_android">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i"</string>
+	<string name="infobox_generic_url_ios">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i"</string>
 
-    <!-- accessibilityLabel for the "1"-icon -->
-    <string name="wallet_scanner_how_it_works_accessibility_icon1">"First"</string>
+	<!-- accessibilityLabel for the "1"-icon -->
+	<string name="wallet_scanner_how_it_works_accessibility_icon1">"First"</string>
 
-    <!-- accessibilityLabel for the "2"-icon -->
-    <string name="wallet_scanner_how_it_works_accessibility_icon2">"Second"</string>
+	<!-- accessibilityLabel for the "2"-icon -->
+	<string name="wallet_scanner_how_it_works_accessibility_icon2">"Second"</string>
 
-    <!-- accessibilityLabel for the "3"-icon -->
-    <string name="wallet_scanner_how_it_works_accessibility_icon3">"Third"</string>
+	<!-- accessibilityLabel for the "3"-icon -->
+	<string name="wallet_scanner_how_it_works_accessibility_icon3">"Third"</string>
 
-    <!-- Reise-Check: Label des Buttons um Gültigkeit im Ausland zu prüfen -->
-    <string name="wallet_foreign_rules_check_button">"Validity abroad"</string>
+	<!-- Reise-Check: Label des Buttons um Gültigkeit im Ausland zu prüfen -->
+	<string name="wallet_foreign_rules_check_button">"Validity abroad"</string>
 
-    <!-- Reise-Check: Titel des Reise-Check Screens -->
-    <string name="wallet_foreign_rules_check_title">"Validity for travel abroad"</string>
+	<!-- Reise-Check: Titel des Reise-Check Screens -->
+	<string name="wallet_foreign_rules_check_title">"Validity for travel abroad"</string>
 
-    <!-- Reise-Check: Untertitel des Reise-Check Screens -->
-    <string name="wallet_foreign_rules_check_subtitle">"Before you travel abroad, find out whether your COVID certificate will be valid at the moment you enter your destination country."</string>
+	<!-- Reise-Check: Untertitel des Reise-Check Screens -->
+	<string name="wallet_foreign_rules_check_subtitle">"Before you travel abroad, find out whether your COVID certificate will be valid at the moment you enter your destination country."</string>
 
-    <!-- Reise-Check: Titel der Länder- und Datumsauswahl -->
-    <string name="wallet_foreign_rules_check_form_title">"Check for:"</string>
+	<!-- Reise-Check: Titel der Länder- und Datumsauswahl -->
+	<string name="wallet_foreign_rules_check_form_title">"Check for:"</string>
 
-    <!-- Reise-Check: Label des Länder Eingabefeldes -->
-    <string name="wallet_foreign_rules_check_country_label">"Country:"</string>
+	<!-- Reise-Check: Label des Länder Eingabefeldes -->
+	<string name="wallet_foreign_rules_check_country_label">"Country:"</string>
 
-    <!-- Reise-Check: Wert wenn kein Land ausgewählt -->
-    <string name="wallet_foreign_rules_check_country_empty_label">"Select"</string>
+	<!-- Reise-Check: Wert wenn kein Land ausgewählt -->
+	<string name="wallet_foreign_rules_check_country_empty_label">"Select"</string>
 
-    <!-- Reise-Check: Label des Datum Eingabefeldes -->
-    <string name="wallet_foreign_rules_check_date_label">"Entering on:"</string>
+	<!-- Reise-Check: Label des Datum Eingabefeldes -->
+	<string name="wallet_foreign_rules_check_date_label">"Entering on:"</string>
 
-    <!-- Reise-Check: Fehlermeldung wenn Datum in der Vergangenheit liegt -->
-    <string name="wallet_foreign_rules_check_date_in_past_error">"Time entered is in the past"</string>
+	<!-- Reise-Check: Fehlermeldung wenn Datum in der Vergangenheit liegt -->
+	<string name="wallet_foreign_rules_check_date_in_past_error">"Time entered is in the past"</string>
 
-    <!-- Reise-Check: Titel des Hinweise Abschnittes -->
-    <string name="wallet_foreign_rules_check_hints_title">"Please note"</string>
+	<!-- Reise-Check: Titel des Hinweise Abschnittes -->
+	<string name="wallet_foreign_rules_check_hints_title">"Please note"</string>
 
-    <!-- Reise-Check: Label für den Mehr Informationen Button -->
-    <string name="wallet_foreign_rules_check_hints_more_info_label">"You’ll find further information at"</string>
+	<!-- Reise-Check: Label für den Mehr Informationen Button -->
+	<string name="wallet_foreign_rules_check_hints_more_info_label">"You’ll find further information at"</string>
 
-    <!-- Reise-Check: Prüfstatus wenn noch kein Land ausgewählt wurde -->
-    <string name="wallet_foreign_rules_check_state_empty">"Please select a country and date of entry."</string>
+	<!-- Reise-Check: Prüfstatus wenn noch kein Land ausgewählt wurde -->
+	<string name="wallet_foreign_rules_check_state_empty">"Please select a country and date of entry."</string>
 
-    <!-- Reise-Check: Titel des Auswahldialoges für das Land -->
-    <string name="wallet_foreign_rules_check_country_picker_title">"Select country"</string>
+	<!-- Reise-Check: Titel des Auswahldialoges für das Land -->
+	<string name="wallet_foreign_rules_check_country_picker_title">"Select country"</string>
 
-    <!-- Reise-Check: Erste Zeile des Prüfstatus wenn Zertifikat gültig ist -->
-    <string name="wallet_foreign_rules_check_state_valid">"Valid for entry to:"</string>
+	<!-- Reise-Check: Erste Zeile des Prüfstatus wenn Zertifikat gültig ist -->
+	<string name="wallet_foreign_rules_check_state_valid">"Valid for entry to:"</string>
 
-    <!-- Reise-Check: Erste Zeile des Prüfstatus wenn Zertifikat ungültig ist -->
-    <string name="wallet_foreign_rules_check_state_invalid">"Not valid for entry to:"</string>
+	<!-- Reise-Check: Erste Zeile des Prüfstatus wenn Zertifikat ungültig ist -->
+	<string name="wallet_foreign_rules_check_state_invalid">"Not valid for entry to:"</string>
 
-    <!-- Reise-Check: Zweite Zeile des Prüfstatus wenn Zertifikat (un-)gültig ist. {COUNTRY} und {DATE} nicht übersetzen -->
-    <string name="wallet_foreign_rules_check_state_country_and_date">"{COUNTRY}, {DATE}"</string>
+	<!-- Reise-Check: Zweite Zeile des Prüfstatus wenn Zertifikat (un-)gültig ist. {COUNTRY} und {DATE} nicht übersetzen -->
+	<string name="wallet_foreign_rules_check_state_country_and_date">"{COUNTRY}, {DATE}"</string>
 
-    <!-- Error-Titel falls das Reisefeature ("Gültigkeit im Ausland") im Offline-Modus gestartet wurde -->
-    <string name="wallet_foreign_rules_check_error_title">"Error while loading available countries"</string>
+	<!-- Error-Titel falls das Reisefeature ("Gültigkeit im Ausland") im Offline-Modus gestartet wurde -->
+	<string name="wallet_foreign_rules_check_error_title">"Error while loading available countries"</string>
 
-    <!-- Error-Text falls das Reisefeature ("Gültigkeit im Ausland") im Offline-Modus gestartet wurde -->
-    <string name="wallet_foreign_rules_check_network_error_text">"To check certificate validity your smartphone must be connected to the internet."</string>
+	<!-- Error-Text falls das Reisefeature ("Gültigkeit im Ausland") im Offline-Modus gestartet wurde -->
+	<string name="wallet_foreign_rules_check_network_error_text">"To check certificate validity your smartphone must be connected to the internet."</string>
 
-    <!-- Reisefeature: Hinweis 1 -->
-    <string name="wallet_foreign_rules_check_hint_2">"Entry rules can change. So check the validity shortly before you depart, and go online to make sure of the latest entry rules for your destination country."</string>
+	<!-- Reisefeature: Hinweis 1 -->
+	<string name="wallet_foreign_rules_check_hint_2">"Entry rules can change. So check the validity shortly before you depart, and go online to make sure of the latest entry rules for your destination country."</string>
 
-    <!-- Reisefeature: Hinweis 2 -->
-    <string name="wallet_foreign_rules_check_hint_3">"The above information relates only to the rules for entering your destination country. Different rules may apply to settings where a certificate is required within the country."</string>
+	<!-- Reisefeature: Hinweis 2 -->
+	<string name="wallet_foreign_rules_check_hint_3">"The above information relates only to the rules for entering your destination country. Different rules may apply to settings where a certificate is required within the country."</string>
 
-    <!-- Reisefeature: Hinweis 3 -->
-    <string name="wallet_foreign_rules_check_hint_1">"The federal government assumes no liability for the up-to-dateness or completeness of the information provided."</string>
+	<!-- Reisefeature: Hinweis 3 -->
+	<string name="wallet_foreign_rules_check_hint_1">"The federal government assumes no liability for the up-to-dateness or completeness of the information provided."</string>
 
-    <!-- Reisefeature: Hinweis 4 -->
-    <string name="wallet_foreign_rules_check_hint_4">"Couldn’t find the country you were looking for? Not all countries accept COVID certificates; it might also be that no entry rules have been made available."</string>
+	<!-- Reisefeature: Hinweis 4 -->
+	<string name="wallet_foreign_rules_check_hint_4">"Couldn’t find the country you were looking for? Not all countries accept COVID certificates; it might also be that no entry rules have been made available."</string>
 
-    <!-- Reisefeature: Text des Mehr Infos Buttons -->
-    <string name="wallet_foreign_rules_check_hints_more_info_link_text">"reopen.europa.eu"</string>
+	<!-- Reisefeature: Text des Mehr Infos Buttons -->
+	<string name="wallet_foreign_rules_check_hints_more_info_link_text">"reopen.europa.eu"</string>
 
-    <!-- Reisefeature: URL die geöffnet wird wenn auf den Mehr Info Button geklickt wird -->
-    <string name="wallet_foreign_rules_check_hints_more_info_link_url">"https://reopen.europa.eu/"</string>
+	<!-- Reisefeature: URL die geöffnet wird wenn auf den Mehr Info Button geklickt wird -->
+	<string name="wallet_foreign_rules_check_hints_more_info_link_url">"https://reopen.europa.eu/"</string>
 
-    <!-- RAT-Umwandlung:  Titel bei Zertifikat -->
-    <string name="rat_conversion_overview_title">"New: EU-compatible version"</string>
+	<!-- RAT-Umwandlung:  Titel bei Zertifikat -->
+	<string name="rat_conversion_overview_title">"New: EU-compatible version"</string>
 
-    <!-- RAT-Umwandlung: Text bei Zertifikat -->
-    <string name="rat_conversion_overview_text">"You can request an EU-compatible version of this COVID certificate."</string>
+	<!-- RAT-Umwandlung: Text bei Zertifikat -->
+	<string name="rat_conversion_overview_text">"You can request an EU-compatible version of this COVID certificate."</string>
 
-    <!-- RAT-Umwandlung: Button-Text zu Umwandlung Detail -->
-    <string name="rat_conversion_overview_button">"Find out more"</string>
+	<!-- RAT-Umwandlung: Button-Text zu Umwandlung Detail -->
+	<string name="rat_conversion_overview_button">"Find out more"</string>
 
-    <!-- RAT-Umwandlung: Titel Detail -->
-    <string name="rat_conversion_title">"Apply for a COVID certificate (EU-compatible)"</string>
+	<!-- RAT-Umwandlung: Titel Detail -->
+	<string name="rat_conversion_title">"Apply for a COVID certificate (EU-compatible)"</string>
 
-    <!-- RAT-Umwandlung: Text auf Detail -->
-    <string name="rat_conversion_text">"COVID recovery certificates issued on the basis of rapid antigen tests are now also accepted in the EU.
+	<!-- RAT-Umwandlung: Text auf Detail -->
+	<string name="rat_conversion_text">"COVID recovery certificates issued on the basis of rapid antigen tests are now also accepted in the EU.
 
 You have the option of requesting an EU-compatible version of this certificate via the National Application Office."</string>
 
-    <!-- RAT-Umwandlung: Title bei Formular-Verlinkung -->
-    <string name="rat_conversion_form_title">"To the National Application Office's online form"</string>
+	<!-- RAT-Umwandlung: Title bei Formular-Verlinkung -->
+	<string name="rat_conversion_form_title">"To the National Application Office's online form"</string>
 
-    <!-- Rat-Umwandlung: Text zum Formular -->
-    <string name="rat_conversion_form_text">"I give my consent for the data in this COVID certificate to be transferred to the form of the National Application Office (a website of the Swiss federal government)."</string>
+	<!-- Rat-Umwandlung: Text zum Formular -->
+	<string name="rat_conversion_form_text">"I give my consent for the data in this COVID certificate to be transferred to the form of the National Application Office (a website of the Swiss federal government)."</string>
 
-    <!-- RAT-Umwandlung: Absprung Button -->
-    <string name="rat_conversion_form_button">"To the form"</string>
+	<!-- RAT-Umwandlung: Absprung Button -->
+	<string name="rat_conversion_form_button">"To the form"</string>
 
-    <!-- RAT-Umwandlung: Linktext zur Webseite nationale Antragsstelle -->
-    <string name="rat_conversion_link_antragsstelle">"National Application Office website (no data transferred)"</string>
+	<!-- RAT-Umwandlung: Linktext zur Webseite nationale Antragsstelle -->
+	<string name="rat_conversion_link_antragsstelle">"National Application Office website (no data transferred)"</string>
 
-    <!-- RAT-Umwandlung: Info Text 1 -->
-    <string name="rat_conversion_info1_text">"If your application is successful, the new EU-compatible COVID certificate will be sent to you by post and can then be transferred by you to the app. It is not possible for the certificate to be sent direct to the app."</string>
+	<!-- RAT-Umwandlung: Info Text 1 -->
+	<string name="rat_conversion_info1_text">"If your application is successful, the new EU-compatible COVID certificate will be sent to you by post and can then be transferred by you to the app. It is not possible for the certificate to be sent direct to the app."</string>
 
-    <!-- RAT-Umwandlung: Info 2 Text -->
-    <string name="rat_conversion_info2_text">"Transferring the certificate data to the National Application Office’s online form makes it easier to validate your application."</string>
+	<!-- RAT-Umwandlung: Info 2 Text -->
+	<string name="rat_conversion_info2_text">"Transferring the certificate data to the National Application Office’s online form makes it easier to validate your application."</string>
 
-    <!-- Die URL für das Formular, mit dem für ein RAT Genesungszert ein reguläres Genesungszert beantragt werden kann -->
-    <string name="wallet_rat_recovery_conversion_url">"https://covidcertificate-form.admin.ch/immunityrequest"</string>
+	<!-- Die URL für das Formular, mit dem für ein RAT Genesungszert ein reguläres Genesungszert beantragt werden kann -->
+	<string name="wallet_rat_recovery_conversion_url">"https://covidcertificate-form.admin.ch/immunityrequest"</string>
 
-    <!-- RAT-Umwandlung: Titel vor Infos -->
-    <string name="rat_conversion_info_title">"Further information"</string>
+	<!-- RAT-Umwandlung: Titel vor Infos -->
+	<string name="rat_conversion_info_title">"Further information"</string>
 
-    <!-- cert renewal general info heading -->
-    <string name="cert_renewal_info_info_heading">"What does this mean?"</string>
+	<!-- cert renewal general info heading -->
+	<string name="cert_renewal_info_info_heading">"What does this mean?"</string>
 
-    <!-- cert renewal general info text 1 -->
-    <string name="cert_renewal_info_info_text_1">"The QR codes used for COVID certificates have limited technical validity"</string>
+	<!-- cert renewal general info text 1 -->
+	<string name="cert_renewal_info_info_text_1">"The QR codes used for COVID certificates have limited technical validity"</string>
 
-    <!-- cert renewal general info text 2 -->
-    <string name="cert_renewal_info_info_text_2">"To enable this certificate to continue to be checked (e.g. when you’re travelling), you must renew the QR code."</string>
+	<!-- cert renewal general info text 2 -->
+	<string name="cert_renewal_info_info_text_2">"To enable this certificate to continue to be checked (e.g. when you’re travelling), you must renew the QR code."</string>
 
-    <!-- cert renewal general info text 3 -->
-    <string name="cert_renewal_info_info_text_3">"You can do this directly here in the app (provided you have an internet connection). The data in your current certificate will be encrypted and sent to the federal government’s COVID certificate issuing system for a new QR code to be issued. This QR code is then sent back to the app. Once the new QR code has been issued and the data sent, the data on the government system are deleted."</string>
+	<!-- cert renewal general info text 3 -->
+	<string name="cert_renewal_info_info_text_3">"You can do this directly here in the app (provided you have an internet connection). The data in your current certificate will be encrypted and sent to the federal government’s COVID certificate issuing system for a new QR code to be issued. This QR code is then sent back to the app. Once the new QR code has been issued and the data sent, the data on the government system are deleted."</string>
 
-    <!-- cert renewal general info text 4 -->
-    <string name="cert_renewal_info_info_text_4">"Check out this FAQ to find out why you should also renew the QR code if your vaccination or recovery certificate is about to expire or has already expired under the Swiss validity rules."</string>
+	<!-- cert renewal general info text 4 -->
+	<string name="cert_renewal_info_info_text_4">"Check out this FAQ to find out why you should also renew the QR code if your vaccination or recovery certificate is about to expire or has already expired under the Swiss validity rules."</string>
 
-    <!-- cert renewal info heading for soon to be expired or expired certificates -->
-    <string name="cert_renewal_info_expired_heading">"What does this mean?"</string>
+	<!-- cert renewal info heading for soon to be expired or expired certificates -->
+	<string name="cert_renewal_info_expired_heading">"What does this mean?"</string>
 
-    <!-- cert renewal text 1 for soon to be expired or expired certificates -->
-    <string name="cert_renewal_info_expired_text_1">"The QR codes used for COVID certificates have limited technical validity."</string>
+	<!-- cert renewal text 1 for soon to be expired or expired certificates -->
+	<string name="cert_renewal_info_expired_text_1">"The QR codes used for COVID certificates have limited technical validity."</string>
 
-    <!-- cert renewal text 2 for soon to be expired or expired certificates -->
-    <string name="cert_renewal_info_expired_text_2">"To enable this certificate to continue to be checked (e.g. when you’re travelling), you must renew the QR code."</string>
+	<!-- cert renewal text 2 for soon to be expired or expired certificates -->
+	<string name="cert_renewal_info_expired_text_2">"To enable this certificate to continue to be checked (e.g. when you’re travelling), you must renew the QR code."</string>
 
-    <!-- cert renewal text 3 for soon to be expired or expired certificates -->
-    <string name="cert_renewal_info_expired_text_3">"You can do this directly here in the app (provided you have an internet connection). The data in your current certificate will be encrypted and sent to the federal government’s COVID certificate issuing system for a new QR code to be issued. This QR code is then sent back to the app. Once the new QR code has been issued and the data sent, the data on the government system are deleted."</string>
+	<!-- cert renewal text 3 for soon to be expired or expired certificates -->
+	<string name="cert_renewal_info_expired_text_3">"You can do this directly here in the app (provided you have an internet connection). The data in your current certificate will be encrypted and sent to the federal government’s COVID certificate issuing system for a new QR code to be issued. This QR code is then sent back to the app. Once the new QR code has been issued and the data sent, the data on the government system are deleted."</string>
 
-    <!-- cert renewal text 4 for soon to be expired or expired certificates -->
-    <string name="cert_renewal_info_expired_text_4">"Check out this FAQ to find out why you should also renew the QR code if your vaccination or recovery certificate is about to expire or has already expired under the Swiss validity rules."</string>
+	<!-- cert renewal text 4 for soon to be expired or expired certificates -->
+	<string name="cert_renewal_info_expired_text_4">"Check out this FAQ to find out why you should also renew the QR code if your vaccination or recovery certificate is about to expire or has already expired under the Swiss validity rules."</string>
 
-    <!-- cert renewal info heading for renewed certificates -->
-    <string name="cert_renewal_info_renewed_heading">"Important!"</string>
+	<!-- cert renewal info heading for renewed certificates -->
+	<string name="cert_renewal_info_renewed_heading">"Important!"</string>
 
-    <!-- cert renewal text 1 for renewed certificates -->
-    <string name="cert_renewal_info_renewed_text_1">"Also replace certificates you have previously printed out or stored with this renewed version."</string>
+	<!-- cert renewal text 1 for renewed certificates -->
+	<string name="cert_renewal_info_renewed_text_1">"Also replace certificates you have previously printed out or stored with this renewed version."</string>
 
-    <!-- cert renewal text 2 for renewed certificates -->
-    <string name="cert_renewal_info_renewed_text_2">"The length of time for which a vaccination is recognised in a particular country is not specified in the certificate. Instead, it is calculated in accordance with the specific rules of the country each time the certificate is checked. Renewing the QR code merely ensures that the QR code can be used from a technical point of view."</string>
+	<!-- cert renewal text 2 for renewed certificates -->
+	<string name="cert_renewal_info_renewed_text_2">"The length of time for which a vaccination is recognised in a particular country is not specified in the certificate. Instead, it is calculated in accordance with the specific rules of the country each time the certificate is checked. Renewing the QR code merely ensures that the QR code can be used from a technical point of view."</string>
 
-    <!-- Wallet: Zertifikat QR Code läuft ab am {DATE} -->
-    <string name="wallet_certificate_qr_code_expiration_date">"QR code expiration date (technical)
+	<!-- Wallet: Zertifikat QR Code läuft ab am {DATE} -->
+	<string name="wallet_certificate_qr_code_expiration_date">"QR code expiration date (technical)
 {DATE}"</string>
 
-    <!-- Wallet: Titel der Info-Bubble wenn das Zertifikat erneuert werden muss -->
-    <string name="wallet_certificate_renewal_required_bubble_title">"Renew QR code!"</string>
+	<!-- Wallet: Titel der Info-Bubble wenn das Zertifikat erneuert werden muss -->
+	<string name="wallet_certificate_renewal_required_bubble_title">"Renew QR code!"</string>
 
-    <!-- Wallet: Text der Info-Bubble wenn das Zertifikat erneuert werden muss -->
-    <string name="wallet_certificate_renewal_required_bubble_text">"To continue using this certificate you must renew the QR code."</string>
+	<!-- Wallet: Text der Info-Bubble wenn das Zertifikat erneuert werden muss -->
+	<string name="wallet_certificate_renewal_required_bubble_text">"To continue using this certificate you must renew the QR code."</string>
 
-    <!-- Wallet: Buttontext der Info-Bubble wenn das Zertifikat erneuert werden muss -->
-    <string name="wallet_certificate_renewal_required_bubble_button">"Find out more"</string>
+	<!-- Wallet: Buttontext der Info-Bubble wenn das Zertifikat erneuert werden muss -->
+	<string name="wallet_certificate_renewal_required_bubble_button">"Find out more"</string>
 
-    <!-- Wallet: Buttontext um den QR Code eines Zertifikats zu erneuern -->
-    <string name="wallet_certificate_renew_now_button">"Renew QR code"</string>
-    <string name="wallet_certificate_renewal_qr_code_expiration">"QR code expiration date"</string>
-    <string name="wallet_certificate_renewal_required_info">"The technical expiration date for this QR code has elapsed (or will elapse soon)."</string>
-    <string name="wallet_certificate_renewal_in_progress_info">"The QR code is being updated"</string>
-    <string name="wallet_certificate_renewal_successful_info">"The QR code has been successfully renewed"</string>
-    <string name="wallet_certificate_renewal_offline_error_title">"No Internet connection"</string>
-    <string name="wallet_certificate_renewal_offline_error_text">"The app must be online for the QR code to be renewed."</string>
-    <string name="wallet_certificate_renewal_general_error_title">"An unexpected error has occurred"</string>
-    <string name="wallet_certificate_renewal_general_error_text">"Please try again later"</string>
+	<!-- Wallet: Buttontext um den QR Code eines Zertifikats zu erneuern -->
+	<string name="wallet_certificate_renew_now_button">"Renew QR code"</string>
+	<string name="wallet_certificate_renewal_qr_code_expiration">"QR code expiration date"</string>
+	<string name="wallet_certificate_renewal_required_info">"The technical expiration date for this QR code has elapsed (or will elapse soon)."</string>
+	<string name="wallet_certificate_renewal_in_progress_info">"The QR code is being updated"</string>
+	<string name="wallet_certificate_renewal_successful_info">"The QR code has been successfully renewed"</string>
+	<string name="wallet_certificate_renewal_offline_error_title">"No Internet connection"</string>
+	<string name="wallet_certificate_renewal_offline_error_text">"The app must be online for the QR code to be renewed."</string>
+	<string name="wallet_certificate_renewal_general_error_title">"An unexpected error has occurred"</string>
+	<string name="wallet_certificate_renewal_general_error_text">"Please try again later"</string>
 
-    <!-- Wallet: Titel der Info-Bubble wenn das Zertifikat erfolgreich erneuert wurde -->
-    <string name="wallet_certificate_renewal_successful_bubble_title">"Successfully renewed"</string>
+	<!-- Wallet: Titel der Info-Bubble wenn das Zertifikat erfolgreich erneuert wurde -->
+	<string name="wallet_certificate_renewal_successful_bubble_title">"Successfully renewed"</string>
 
-    <!-- Wallet: Text der Info-Bubble wenn das Zertifikat erfolgreich erneuert wurde -->
-    <string name="wallet_certificate_renewal_successful_bubble_text">"Also replace certificates that have been printed out or stored with this renewed version."</string>
+	<!-- Wallet: Text der Info-Bubble wenn das Zertifikat erfolgreich erneuert wurde -->
+	<string name="wallet_certificate_renewal_successful_bubble_text">"Also replace certificates that have been printed out or stored with this renewed version."</string>
 
-    <!-- Wallet: Button der Info-Bubble wenn das Zertifikat erfolgreich erneuert wurde -->
-    <string name="wallet_certificate_renewal_successful_bubble_button">"More information"</string>
+	<!-- Wallet: Button der Info-Bubble wenn das Zertifikat erfolgreich erneuert wurde -->
+	<string name="wallet_certificate_renewal_successful_bubble_button">"More information"</string>
 
-    <!-- Wallet: QR Code des Zertifikats abgelaufen -->
-    <string name="wallet_error_qr_code_expired">"The technical expiration date for this QR code has elapsed."</string>
-    <string name="wallet_certificate_renewal_rate_limit_error_title">"24h-limit reached"</string>
-    <string name="wallet_certificate_renewal_rate_limit_error_text">"QR code updated too often. Update temporarily blocked."</string>
-    <string name="wallet_certificate_renewal_faq_link_text">"To the FAQ"</string>
-    <string name="wallet_certificate_renewal_faq_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/why-should-i-renew-qr-code-my-covid-certificate-even-though-certificate-about"</string>
-    <string name="terms_and_conditions_update_boarding_title">"Update"</string>
-    <string name="terms_and_conditions_update_boarding_text">"Certain points of the terms of use and privacy statement for the app have been updated and adapted in line with the relevant legal bases."</string>
-    <string name="wallet_validity_since_vaccination_date"></string>
-    <string name="wallet_validity_since_test_date"></string>
+	<!-- Wallet: QR Code des Zertifikats abgelaufen -->
+	<string name="wallet_error_qr_code_expired">"The technical expiration date for this QR code has elapsed."</string>
+	<string name="wallet_certificate_renewal_rate_limit_error_title">"24h-limit reached"</string>
+	<string name="wallet_certificate_renewal_rate_limit_error_text">"QR code updated too often. Update temporarily blocked."</string>
+	<string name="wallet_certificate_renewal_faq_link_text">"To the FAQ"</string>
+	<string name="wallet_certificate_renewal_faq_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/why-should-i-renew-qr-code-my-covid-certificate-even-though-certificate-about"</string>
+	<string name="terms_and_conditions_update_boarding_title">"Update"</string>
+	<string name="terms_and_conditions_update_boarding_text">"Certain points of the terms of use and privacy statement for the app have been updated and adapted in line with the relevant legal bases."</string>
+	<string name="wallet_validity_since_vaccination_date"></string>
+	<string name="wallet_validity_since_test_date"></string>
+	<string name="wallet_validity_since_more_hours_prefix"></string>
+	<string name="wallet_validity_since_recovery_date"></string>
 
-    <!-- vor 2 Tagen - must be before "2 Tagen"! -->
-    <string name="wallet_validity_since_prefix"></string>
+	<!-- vor 2 Tagen - must be before "2 Tagen"! -->
+	<string name="wallet_validity_since_prefix"></string>
 
-    <!-- vor 1 Stunde -->
-    <string name="wallet_validity_since_hours_singular"></string>
+	<!-- vor 1 Stunde -->
+	<string name="wallet_validity_since_hours_singular"></string>
 
-    <!-- vor 2 Stunden -->
-    <string name="wallet_validity_since_hours_plural"></string>
+	<!-- vor 2 Stunden -->
+	<string name="wallet_validity_since_hours_plural"></string>
 
-    <!-- vor 1 Tag -->
-    <string name="wallet_validity_since_days_singular"></string>
+	<!-- vor 1 Tag -->
+	<string name="wallet_validity_since_days_singular"></string>
 
-    <!-- vor 2 Tagen -->
-    <string name="wallet_validity_since_days_plural"></string>
+	<!-- vor 2 Tagen -->
+	<string name="wallet_validity_since_days_plural"></string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1453,7 +1453,6 @@ This certificate is only valid for a limited period of time. You can check the c
     <string name="wallet_certificate_antigen_positive_date">"Date of first positive test result"</string>
 
     <!-- Wallet: Blaue Box für positiven Antigen-Test -->
-    <!-- Fuzzy -->
     <string name="wallet_certificate_detail_note_positive_antigen">"This certificate is not a travel document.
 &lt;br /&gt;&lt;br /&gt;
 This certificate is only valid for a limited period of time. You can check the current duration of validity in Switzerland at any time using the COVID Certificate app."</string>
@@ -1514,21 +1513,11 @@ This certificate is only valid for a limited period of time. You can check the c
 
     <!-- text for pop up. case: certificate will be invalid within three weeks of validity change. -->
     <string name="wallet_eol_banner_invalid_in_three_weeks_popup_text2"></string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_title">"Back up your certificate!"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_text">"If you uninstall the app or change or lose your smartphone, you will also lose your COVID certificates.
 This means you should also keep a copy of your certificates outside the app by exporting them as PDFs."</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_button">"Find out more"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_android">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i"</string>
-
-    <!-- Fuzzy -->
     <string name="infobox_generic_url_ios">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/i-only-have-my-covid-certificate-electronically-covid-certificate-app-how-can-i"</string>
 
     <!-- accessibilityLabel for the "1"-icon -->
@@ -1592,15 +1581,12 @@ This means you should also keep a copy of your certificates outside the app by e
     <string name="wallet_foreign_rules_check_network_error_text">"To check certificate validity your smartphone must be connected to the internet."</string>
 
     <!-- Reisefeature: Hinweis 1 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_2">"Entry rules can change. So check the validity shortly before you depart, and go online to make sure of the latest entry rules for your destination country."</string>
 
     <!-- Reisefeature: Hinweis 2 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_3">"The above information relates only to the rules for entering your destination country. Different rules may apply to settings where a certificate is required within the country."</string>
 
     <!-- Reisefeature: Hinweis 3 -->
-    <!-- Fuzzy -->
     <string name="wallet_foreign_rules_check_hint_1">"The federal government assumes no liability for the up-to-dateness or completeness of the information provided."</string>
 
     <!-- Reisefeature: Hinweis 4 -->
@@ -1648,7 +1634,6 @@ You have the option of requesting an EU-compatible version of this certificate v
     <string name="rat_conversion_info2_text">"Transferring the certificate data to the National Application Office’s online form makes it easier to validate your application."</string>
 
     <!-- Die URL für das Formular, mit dem für ein RAT Genesungszert ein reguläres Genesungszert beantragt werden kann -->
-    <!-- Fuzzy -->
     <string name="wallet_rat_recovery_conversion_url">"https://covidcertificate-form.admin.ch/immunityrequest"</string>
 
     <!-- RAT-Umwandlung: Titel vor Infos -->
@@ -1727,7 +1712,6 @@ You have the option of requesting an EU-compatible version of this certificate v
     <string name="wallet_certificate_renewal_successful_bubble_button">"More information"</string>
 
     <!-- Wallet: QR Code des Zertifikats abgelaufen -->
-    <!-- Fuzzy -->
     <string name="wallet_error_qr_code_expired">"The technical expiration date for this QR code has elapsed."</string>
     <string name="wallet_certificate_renewal_rate_limit_error_title">"24h-limit reached"</string>
     <string name="wallet_certificate_renewal_rate_limit_error_text">"QR code updated too often. Update temporarily blocked."</string>
@@ -1735,4 +1719,21 @@ You have the option of requesting an EU-compatible version of this certificate v
     <string name="wallet_certificate_renewal_faq_link_url">"https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/haeufig-gestellte-fragen.html?faq-url=/covid/en/covid-certificate/why-should-i-renew-qr-code-my-covid-certificate-even-though-certificate-about"</string>
     <string name="terms_and_conditions_update_boarding_title">"Update"</string>
     <string name="terms_and_conditions_update_boarding_text">"Certain points of the terms of use and privacy statement for the app have been updated and adapted in line with the relevant legal bases."</string>
+    <string name="wallet_validity_since_vaccination_date"></string>
+    <string name="wallet_validity_since_test_date"></string>
+
+    <!-- vor 2 Tagen - must be before "2 Tagen"! -->
+    <string name="wallet_validity_since_prefix"></string>
+
+    <!-- vor 1 Stunde -->
+    <string name="wallet_validity_since_hours_singular"></string>
+
+    <!-- vor 2 Stunden -->
+    <string name="wallet_validity_since_hours_plural"></string>
+
+    <!-- vor 1 Tag -->
+    <string name="wallet_validity_since_days_singular"></string>
+
+    <!-- vor 2 Tagen -->
+    <string name="wallet_validity_since_days_plural"></string>
 </resources>

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
@@ -764,11 +764,12 @@ class CertificateDetailFragment : Fragment() {
 			binding.certificateDetailInfoValidityLeftText.text = context.getString(leftLabelStringId)
 			binding.certificateDetailInfoValidityLeftBold.text =
 				getFormattedValidityDate(validityRange?.validFrom, certificateHolder.certType, state)
+			binding.certificateDetailInfoValidityLeftBold.visibility = View.VISIBLE
 			binding.certificateDetailInfoValidityRightText.text = context.getString(R.string.wallet_validity_since_prefix)
 			binding.certificateDetailInfoValidityRightBold.text = getFormattedValiditySince(context, validityRange?.validFrom)
 		} else {
 			binding.certificateDetailInfoValidityLeftText.text = context.getString(R.string.wallet_certificate_validity)
-			binding.certificateDetailInfoValidityLeftBold.text = ""
+			binding.certificateDetailInfoValidityLeftBold.visibility = View.GONE
 			binding.certificateDetailInfoValidityRightText.text = context.getString(R.string.wallet_certificate_valid_until)
 			binding.certificateDetailInfoValidityRightBold.text =
 				getFormattedValidityDate(validityRange?.validUntil, certificateHolder.certType, state)

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/detail/CertificateDetailFragment.kt
@@ -215,7 +215,8 @@ class CertificateDetailFragment : Fragment() {
 					val isValidOnlyInSwitzerland = it.state.isValidOnlyInSwitzerland()
 					binding.certificateForeignValidityButton.isVisible = isFeatureEnabled && isNotInvalid && !isValidOnlyInSwitzerland
 
-					updateStatusInfo(it.state)
+					val state = cheatUiOnCertsExpiredInSwitzerland(currentConfig, it.state)
+					updateStatusInfo(state)
 				}
 		}
 

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/pager/CertificatePagerFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/pager/CertificatePagerFragment.kt
@@ -110,8 +110,10 @@ class CertificatePagerFragment : Fragment() {
 	private fun setupStatusInfo() {
 		certificatesViewModel.statefulWalletItems.observe(viewLifecycleOwner) { items ->
 			items.filterIsInstance(StatefulWalletItem.VerifiedCertificate::class.java)
-				.find { it.qrCodeData == qrCodeData }?.let {
-					updateStatusInfo(it.state)
+				.find { it.qrCodeData == qrCodeData }?.let { verifiedCert ->
+					val currentConfig = ConfigRepository.getCurrentConfig(requireContext())
+					val state = cheatUiOnCertsExpiredInSwitzerland(currentConfig, verifiedCert.state)
+					updateStatusInfo(state)
 				}
 		}
 
@@ -242,7 +244,7 @@ class CertificatePagerFragment : Fragment() {
 		binding.certificatePageBirthdate.setTextColor(textColor)
 	}
 
-	private fun displayQrCodeRenewalBannerIfNecessary(showRenewBanner: String?) : Boolean {
+	private fun displayQrCodeRenewalBannerIfNecessary(showRenewBanner: String?): Boolean {
 		val wasRecentlyRenewed = certificateHolder?.let { certificatesViewModel.wasCertificateRecentlyRenewed(it) } ?: false
 
 		when {

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/pager/CertificatePagerFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/homescreen/pager/CertificatePagerFragment.kt
@@ -112,7 +112,7 @@ class CertificatePagerFragment : Fragment() {
 			items.filterIsInstance(StatefulWalletItem.VerifiedCertificate::class.java)
 				.find { it.qrCodeData == qrCodeData }?.let { verifiedCert ->
 					val currentConfig = ConfigRepository.getCurrentConfig(requireContext())
-					val state = cheatUiOnCertsExpiredInSwitzerland(currentConfig, verifiedCert.state)
+					val state = hideExpiryInSwitzerland(currentConfig, verifiedCert.state)
 					updateStatusInfo(state)
 				}
 		}

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/list/CertificatesListFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/list/CertificatesListFragment.kt
@@ -31,7 +31,7 @@ import ch.admin.bag.covidcertificate.wallet.light.CertificateLightDetailFragment
 import ch.admin.bag.covidcertificate.wallet.transfercode.TransferCodeDetailFragment
 import ch.admin.bag.covidcertificate.wallet.transfercode.model.TransferCodeConversionState
 import ch.admin.bag.covidcertificate.wallet.transfercode.model.TransferCodeModel
-import ch.admin.bag.covidcertificate.wallet.util.cheatUiOnCertsExpiredInSwitzerland
+import ch.admin.bag.covidcertificate.wallet.util.hideExpiryInSwitzerland
 
 class CertificatesListFragment : Fragment() {
 
@@ -108,10 +108,11 @@ class CertificatesListFragment : Fragment() {
 							.find { cert -> cert.qrCodeData == item.verifiedCertificate.qrCodeData }
 							?.let { cert ->
 								val currentConfig = ConfigRepository.getCurrentConfig(requireContext())
-								val cheatedState = cheatUiOnCertsExpiredInSwitzerland(currentConfig, cert.state)
-								val cheatedCert =
-									StatefulWalletItem.VerifiedCertificate(cert.qrCodeData, cert.certificateHolder, cheatedState)
-								item.copy(cheatedCert)
+								val expiryHiddenState = hideExpiryInSwitzerland(currentConfig, cert.state)
+								val expiryHiddenCert = StatefulWalletItem.VerifiedCertificate(
+									cert.qrCodeData, cert.certificateHolder, expiryHiddenState
+								)
+								item.copy(expiryHiddenCert)
 							}
 							?: item
 					}

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/list/CertificatesListFragment.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/list/CertificatesListFragment.kt
@@ -17,7 +17,6 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import ch.admin.bag.covidcertificate.common.net.ConfigRepository
 import ch.admin.bag.covidcertificate.common.views.hideAnimated
 import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.CertificateHolder
 import ch.admin.bag.covidcertificate.sdk.core.models.state.VerificationState
@@ -31,7 +30,6 @@ import ch.admin.bag.covidcertificate.wallet.light.CertificateLightDetailFragment
 import ch.admin.bag.covidcertificate.wallet.transfercode.TransferCodeDetailFragment
 import ch.admin.bag.covidcertificate.wallet.transfercode.model.TransferCodeConversionState
 import ch.admin.bag.covidcertificate.wallet.transfercode.model.TransferCodeModel
-import ch.admin.bag.covidcertificate.wallet.util.hideExpiryInSwitzerland
 
 class CertificatesListFragment : Fragment() {
 
@@ -106,14 +104,7 @@ class CertificatesListFragment : Fragment() {
 						statefulWalletItems
 							.filterIsInstance(StatefulWalletItem.VerifiedCertificate::class.java)
 							.find { cert -> cert.qrCodeData == item.verifiedCertificate.qrCodeData }
-							?.let { cert ->
-								val currentConfig = ConfigRepository.getCurrentConfig(requireContext())
-								val expiryHiddenState = hideExpiryInSwitzerland(currentConfig, cert.state)
-								val expiryHiddenCert = StatefulWalletItem.VerifiedCertificate(
-									cert.qrCodeData, cert.certificateHolder, expiryHiddenState
-								)
-								item.copy(expiryHiddenCert)
-							}
+							?.let { cert -> item.copy(cert) }
 							?: item
 					}
 					is WalletDataListItem.TransferCodeItem -> {

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/list/WalletDataListItem.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/list/WalletDataListItem.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import ch.admin.bag.covidcertificate.common.net.ConfigRepository
 import ch.admin.bag.covidcertificate.sdk.core.data.ErrorCodes
 import ch.admin.bag.covidcertificate.sdk.core.extensions.isChAusnahmeTest
 import ch.admin.bag.covidcertificate.sdk.core.extensions.isPositiveRatTest
@@ -34,6 +35,7 @@ import ch.admin.bag.covidcertificate.wallet.transfercode.model.TransferCodeModel
 import ch.admin.bag.covidcertificate.wallet.transfercode.net.DeliveryRepository
 import ch.admin.bag.covidcertificate.wallet.util.getInvalidContentAlpha
 import ch.admin.bag.covidcertificate.wallet.util.getInvalidQrCodeAlpha
+import ch.admin.bag.covidcertificate.wallet.util.hideExpiryInSwitzerland
 import ch.admin.bag.covidcertificate.wallet.util.isOfflineMode
 
 sealed class WalletDataListItem {
@@ -44,7 +46,10 @@ sealed class WalletDataListItem {
 
 		fun bindView(itemView: View, onCertificateClickListener: ((Pair<CertificateHolder, String?>) -> Unit)? = null) {
 			val binding = ItemCertificateListBinding.bind(itemView)
-			val state = verifiedCertificate.state
+
+			val currentConfig = ConfigRepository.getCurrentConfig(itemView.context)
+			val state = hideExpiryInSwitzerland(currentConfig, verifiedCertificate.state)
+
 			val certificate = verifiedCertificate.certificateHolder
 			val certType = certificate?.certType
 

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/util/VerificationStateUtil.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/util/VerificationStateUtil.kt
@@ -14,7 +14,6 @@ import android.content.Context
 import android.text.SpannableString
 import androidx.annotation.ColorRes
 import ch.admin.bag.covidcertificate.common.config.ConfigModel
-import ch.admin.bag.covidcertificate.common.net.ConfigRepository
 import ch.admin.bag.covidcertificate.common.util.addBoldDate
 import ch.admin.bag.covidcertificate.common.util.makeSubStringBold
 import ch.admin.bag.covidcertificate.sdk.core.data.ErrorCodes
@@ -127,12 +126,14 @@ fun VerificationState.getInvalidContentAlpha(): Float {
 fun hideExpiryInSwitzerland(currentConfig: ConfigModel?, inState: VerificationState): VerificationState {
 	var outState = inState
 
-	if (currentConfig?.showValiditySince == true
+	if (currentConfig?.showValidityState == false
 		&& inState is VerificationState.INVALID
 		&& inState.signatureState == CheckSignatureState.SUCCESS
 		&& inState.revocationState !is CheckRevocationState.INVALID
-		&& inState.nationalRulesState is CheckNationalRulesState.NOT_VALID_ANYMORE
+		&& (inState.nationalRulesState is CheckNationalRulesState.NOT_VALID_ANYMORE
+				|| inState.nationalRulesState is CheckNationalRulesState.NOT_YET_VALID)
 	) {
+
 		val dummySuccessState = SuccessState.WalletSuccessState(
 			isValidOnlyInSwitzerland = false,
 			validityRange = inState.validityRange,

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/util/VerificationStateUtil.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/util/VerificationStateUtil.kt
@@ -120,11 +120,16 @@ fun VerificationState.getInvalidContentAlpha(): Float {
 	}
 }
 
+/**
+ * Cheat on certificates that are expired in Switzerland BUT have a valid signature and are NOT revoked.
+ */
 fun cheatUiOnCertsExpiredInSwitzerland(currentConfig: ConfigModel?, inState: VerificationState): VerificationState {
 	var outState = inState
 
-	if (currentConfig?.showValiditySince == true
+	if (currentConfig?.showValiditySince == true // cheating enabled?
 		&& inState is VerificationState.INVALID
+		&& inState.signatureState == CheckSignatureState.SUCCESS
+		&& inState.revocationState !is CheckRevocationState.INVALID
 		&& inState.nationalRulesState is CheckNationalRulesState.NOT_VALID_ANYMORE
 	) {
 		val dummySuccessState = SuccessState.WalletSuccessState(

--- a/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/util/VerificationStateUtil.kt
+++ b/wallet/src/main/java/ch/admin/bag/covidcertificate/wallet/util/VerificationStateUtil.kt
@@ -121,12 +121,13 @@ fun VerificationState.getInvalidContentAlpha(): Float {
 }
 
 /**
- * Cheat on certificates that are expired in Switzerland BUT have a valid signature and are NOT revoked.
+ * Hide expiry info of certificates that are expired in Switzerland BUT have a valid signature and are NOT revoked.
+ * Don't show a grey expired state, but a blue success state.
  */
-fun cheatUiOnCertsExpiredInSwitzerland(currentConfig: ConfigModel?, inState: VerificationState): VerificationState {
+fun hideExpiryInSwitzerland(currentConfig: ConfigModel?, inState: VerificationState): VerificationState {
 	var outState = inState
 
-	if (currentConfig?.showValiditySince == true // cheating enabled?
+	if (currentConfig?.showValiditySince == true
 		&& inState is VerificationState.INVALID
 		&& inState.signatureState == CheckSignatureState.SUCCESS
 		&& inState.revocationState !is CheckRevocationState.INVALID

--- a/wallet/src/main/res/layout/fragment_certificate_detail.xml
+++ b/wallet/src/main/res/layout/fragment_certificate_detail.xml
@@ -241,22 +241,40 @@
 						android:paddingVertical="@dimen/spacing_medium_small"
 						app:backgroundTint="@color/blueish">
 
-						<TextView
-							android:id="@+id/certificate_detail_info_validity_date_disclaimer"
-							style="@style/CovidCertificate.Text"
-							android:layout_width="0dp"
-							android:layout_height="wrap_content"
-							android:layout_weight="1"
-							android:text="@string/wallet_certificate_validity" />
-
 						<LinearLayout
-							android:id="@+id/certificate_detail_info_validity_date_group"
+							android:id="@+id/certificate_detail_info_validity_left_group"
 							android:layout_width="0dp"
 							android:layout_height="wrap_content"
 							android:layout_weight="1"
 							android:orientation="vertical">
 
 							<TextView
+								android:id="@+id/certificate_detail_info_validity_left_text"
+								style="@style/CovidCertificate.Text"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								android:text="@string/wallet_certificate_valid_until"
+								app:backgroundTint="@color/blueish" />
+
+							<TextView
+								android:id="@+id/certificate_detail_info_validity_left_bold"
+								style="@style/CovidCertificate.Text.Bold"
+								android:layout_width="match_parent"
+								android:layout_height="wrap_content"
+								app:backgroundTint="@color/blueish"
+								tools:text="01.01.2022" />
+
+						</LinearLayout>
+
+						<LinearLayout
+							android:id="@+id/certificate_detail_info_validity_right_group"
+							android:layout_width="0dp"
+							android:layout_height="wrap_content"
+							android:layout_weight="1"
+							android:orientation="vertical">
+
+							<TextView
+								android:id="@+id/certificate_detail_info_validity_right_text"
 								style="@style/CovidCertificate.Text"
 								android:layout_width="match_parent"
 								android:layout_height="wrap_content"
@@ -265,7 +283,7 @@
 								app:backgroundTint="@color/blueish" />
 
 							<TextView
-								android:id="@+id/certificate_detail_info_validity_date"
+								android:id="@+id/certificate_detail_info_validity_right_bold"
 								style="@style/CovidCertificate.Text.Bold"
 								android:layout_width="match_parent"
 								android:layout_height="wrap_content"


### PR DESCRIPTION
Add feature flag to either show the "validity until" of certificates (including making them grey when they expire in Switzerland, as before), or showing the "valid since" of certificates (keeping them blue, new).
This is to avoid confusion between the validity in Switzerland and the validity for international travel.

Translations are missing.