### PR TITLE
fix broken url to openfont license

### DIFF
--- a/common/src/main/assets/impressum/de/licence.html
+++ b/common/src/main/assets/impressum/de/licence.html
@@ -43,7 +43,7 @@
 <li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>

--- a/common/src/main/assets/impressum/en/licence.html
+++ b/common/src/main/assets/impressum/en/licence.html
@@ -43,7 +43,7 @@
 <li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>

--- a/common/src/main/assets/impressum/fr/licence.html
+++ b/common/src/main/assets/impressum/fr/licence.html
@@ -43,7 +43,7 @@
 <li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>

--- a/common/src/main/assets/impressum/it/licence.html
+++ b/common/src/main/assets/impressum/it/licence.html
@@ -43,7 +43,7 @@
 <li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>

--- a/common/src/main/assets/impressum/rm/licence.html
+++ b/common/src/main/assets/impressum/rm/licence.html
@@ -43,7 +43,7 @@
 <li><a href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause license</a></li>
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>


### PR DESCRIPTION
The link to the "SIL OPEN FONT LICENSE (OFL-1.1)" is broken in the app. This pull request fixes the url.